### PR TITLE
LPS-65236 Fix session memory leak

### DIFF
--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 2.4.0
+Bundle-Version: 3.0.0
 Export-Package:\
 	com.liferay.portal.bean,\
 	com.liferay.portal.cache.thread.local,\

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -24,6 +24,10 @@
 	<bean class="com.liferay.expando.kernel.util.ExpandoBridgeIndexerUtil" id="com.liferay.expando.kernel.util.ExpandoBridgeIndexerUtil">
 		<property name="expandoBridgeIndexer" ref="com.liferay.expando.kernel.util.ExpandoBridgeIndexer" />
 	</bean>
+	<bean class="com.liferay.portal.servlet.PortalSessionCreatorDestroyerImpl" id="com.liferay.portal.kernel.servlet.PortalSessionCreatorDestroyer" />
+	<bean class="com.liferay.portal.kernel.servlet.PortalSessionCreatorDestroyerUtil" id="com.liferay.portal.kernel.servlet.PortalSessionCreatorDestroyerUtil" >
+		<property name="portalSessionCreatorDestroyer" ref="com.liferay.portal.kernel.servlet.PortalSessionCreatorDestroyer" />
+	</bean>
 	<bean class="com.liferay.mail.util.DummyHook" id="com.liferay.mail.util.DummyHook" />
 	<bean class="com.liferay.portal.convert.database.DatabaseConvertProcess" />
 	<bean class="com.liferay.portal.convert.database.PortalDatabaseConverter" >

--- a/portal-impl/src/com/liferay/portal/servlet/PortalSessionActivationListener.java
+++ b/portal-impl/src/com/liferay/portal/servlet/PortalSessionActivationListener.java
@@ -14,61 +14,13 @@
 
 package com.liferay.portal.servlet;
 
-import com.liferay.portal.kernel.servlet.PortalSessionCreatorDestroyerUtil;
-import com.liferay.portal.kernel.util.TransientValue;
-
-import java.io.Serializable;
-
-import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpSessionActivationListener;
-import javax.servlet.http.HttpSessionEvent;
-
 /**
  * @author Alexander Chow
+ * @deprecated As of 7.0.0, replaced by {@link
+ *             com.liferay.portal.kernel.servlet.
+ *             PortalSessionActivationListener}
  */
+@Deprecated
 public class PortalSessionActivationListener
-	implements HttpSessionActivationListener, Serializable {
-
-	public static PortalSessionActivationListener getInstance() {
-		return _instance;
-	}
-
-	public static PortalSessionActivationListener getInstance(
-		HttpSession session) {
-
-		TransientValue<PortalSessionActivationListener> transientValue =
-			(TransientValue<PortalSessionActivationListener>)
-				session.getAttribute(
-					PortalSessionActivationListener.class.getName());
-
-		PortalSessionActivationListener portalSessionActivationListener = null;
-
-		if (transientValue != null) {
-			portalSessionActivationListener = transientValue.getValue();
-		}
-
-		return portalSessionActivationListener;
-	}
-
-	public static void setInstance(HttpSession session) {
-		TransientValue<PortalSessionActivationListener> transientValue =
-			new TransientValue<>(PortalSessionActivationListener.getInstance());
-
-		session.setAttribute(
-			PortalSessionActivationListener.class.getName(), transientValue);
-	}
-
-	@Override
-	public void sessionDidActivate(HttpSessionEvent httpSessionEvent) {
-		PortalSessionCreatorDestroyerUtil.createSession(httpSessionEvent);
-	}
-
-	@Override
-	public void sessionWillPassivate(HttpSessionEvent httpSessionEvent) {
-		PortalSessionCreatorDestroyerUtil.destroySession(httpSessionEvent);
-	}
-
-	private static final PortalSessionActivationListener _instance =
-		new PortalSessionActivationListener();
-
+	extends com.liferay.portal.kernel.servlet.PortalSessionActivationListener {
 }

--- a/portal-impl/src/com/liferay/portal/servlet/PortalSessionActivationListener.java
+++ b/portal-impl/src/com/liferay/portal/servlet/PortalSessionActivationListener.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.servlet;
 
+import com.liferay.portal.kernel.servlet.PortalSessionCreatorDestroyerUtil;
 import com.liferay.portal.kernel.util.TransientValue;
 
 import java.io.Serializable;
@@ -59,11 +60,12 @@ public class PortalSessionActivationListener
 
 	@Override
 	public void sessionDidActivate(HttpSessionEvent httpSessionEvent) {
-		new PortalSessionCreator(httpSessionEvent);
+		PortalSessionCreatorDestroyerUtil.createSession(httpSessionEvent);
 	}
 
 	@Override
 	public void sessionWillPassivate(HttpSessionEvent httpSessionEvent) {
+		PortalSessionCreatorDestroyerUtil.destroySession(httpSessionEvent);
 	}
 
 	private static final PortalSessionActivationListener _instance =

--- a/portal-impl/src/com/liferay/portal/servlet/PortalSessionActivator.java
+++ b/portal-impl/src/com/liferay/portal/servlet/PortalSessionActivator.java
@@ -1,0 +1,48 @@
+package com.liferay.portal.servlet;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.PortalSessionContext;
+import com.liferay.portal.kernel.util.BasePortalLifecycle;
+import com.liferay.portal.util.PropsValues;
+
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+
+/**
+ * Created by Kocsis Norbert on 5/24/2016.
+ */
+public class PortalSessionActivator extends BasePortalLifecycle {
+	public PortalSessionActivator(HttpSessionEvent httpSessionEvent) {
+		_httpSessionEvent = httpSessionEvent;
+
+		registerPortalLifecycle(METHOD_INIT);
+	}
+
+	@Override
+	protected void doPortalDestroy() {
+	}
+
+	@Override
+	protected void doPortalInit() {
+		if (PropsValues.SESSION_DISABLED) {
+			return;
+		}
+
+		HttpSession session = _httpSessionEvent.getSession();
+
+		try {
+			PortalSessionContext.put(session.getId(), session);
+		}
+		catch (IllegalStateException ise) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(ise, ise);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PortalSessionCreator.class);
+
+	private final HttpSessionEvent _httpSessionEvent;
+}

--- a/portal-impl/src/com/liferay/portal/servlet/PortalSessionCreatorDestroyerImpl.java
+++ b/portal-impl/src/com/liferay/portal/servlet/PortalSessionCreatorDestroyerImpl.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.servlet;
+
+import com.liferay.portal.kernel.servlet.PortalSessionCreatorDestroyer;
+
+import javax.servlet.http.HttpSessionEvent;
+
+/**
+ * @author Preston Crary
+ */
+public class PortalSessionCreatorDestroyerImpl
+	implements PortalSessionCreatorDestroyer {
+
+	@Override
+	public void createSession(HttpSessionEvent httpSessionEvent) {
+		new PortalSessionCreator(httpSessionEvent);
+	}
+
+	@Override
+	public void destroySession(HttpSessionEvent httpSessionEvent) {
+		new PortalSessionDestroyer(httpSessionEvent);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/servlet/PortalSessionCreatorDestroyerImpl.java
+++ b/portal-impl/src/com/liferay/portal/servlet/PortalSessionCreatorDestroyerImpl.java
@@ -15,6 +15,8 @@
 package com.liferay.portal.servlet;
 
 import com.liferay.portal.kernel.servlet.PortalSessionCreatorDestroyer;
+import com.liferay.portal.kernel.servlet.filters.compoundsessionid.CompoundSessionIdHttpSession;
+import com.liferay.portal.kernel.servlet.filters.compoundsessionid.CompoundSessionIdSplitterUtil;
 
 import javax.servlet.http.HttpSessionEvent;
 
@@ -32,6 +34,32 @@ public class PortalSessionCreatorDestroyerImpl
 	@Override
 	public void destroySession(HttpSessionEvent httpSessionEvent) {
 		new PortalSessionDestroyer(httpSessionEvent);
+	}
+
+	@Override
+	public void activateSession(HttpSessionEvent httpSessionEvent) {
+		if (CompoundSessionIdSplitterUtil.hasSessionDelimiter()) {
+			CompoundSessionIdHttpSession compoundSessionIdHttpSession =
+				new CompoundSessionIdHttpSession(httpSessionEvent.getSession());
+
+			httpSessionEvent = new HttpSessionEvent(
+				compoundSessionIdHttpSession);
+		}
+
+		new PortalSessionActivator(httpSessionEvent);
+	}
+
+	@Override
+	public void passivateSession(HttpSessionEvent httpSessionEvent) {
+		if (CompoundSessionIdSplitterUtil.hasSessionDelimiter()) {
+			CompoundSessionIdHttpSession compoundSessionIdHttpSession =
+				new CompoundSessionIdHttpSession(httpSessionEvent.getSession());
+
+			httpSessionEvent = new HttpSessionEvent(
+				compoundSessionIdHttpSession);
+		}
+
+		new PortalSessionPassivator(httpSessionEvent);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/servlet/PortalSessionListener.java
+++ b/portal-impl/src/com/liferay/portal/servlet/PortalSessionListener.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.cache.thread.local.Lifecycle;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCacheManager;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.PortalSessionActivationListener;
 import com.liferay.portal.kernel.servlet.filters.compoundsessionid.CompoundSessionIdHttpSession;
 import com.liferay.portal.kernel.servlet.filters.compoundsessionid.CompoundSessionIdSplitterUtil;
 import com.liferay.portal.kernel.util.WebKeys;

--- a/portal-impl/src/com/liferay/portal/servlet/PortalSessionPassivator.java
+++ b/portal-impl/src/com/liferay/portal/servlet/PortalSessionPassivator.java
@@ -1,0 +1,51 @@
+package com.liferay.portal.servlet;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.PortalSessionContext;
+import com.liferay.portal.kernel.servlet.PortletSessionTracker;
+import com.liferay.portal.kernel.util.BasePortalLifecycle;
+import com.liferay.portal.util.PropsValues;
+
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+
+/**
+ * Created by Kocsis Norbert on 5/24/2016.
+ */
+public class PortalSessionPassivator extends BasePortalLifecycle {
+	public PortalSessionPassivator(HttpSessionEvent httpSessionEvent) {
+		_httpSessionEvent = httpSessionEvent;
+
+		registerPortalLifecycle(METHOD_INIT);
+	}
+
+	@Override
+	protected void doPortalDestroy() {
+	}
+
+	@Override
+	protected void doPortalInit() {
+		if (PropsValues.SESSION_DISABLED) {
+			return;
+		}
+
+		HttpSession session = _httpSessionEvent.getSession();
+
+		try {
+			PortalSessionContext.remove(session.getId());
+
+			PortletSessionTracker.passivate(session.getId());
+		}
+		catch (IllegalStateException ise) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(ise, ise);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PortalSessionCreator.class);
+
+	private final HttpSessionEvent _httpSessionEvent;
+}

--- a/portal-impl/src/com/liferay/portal/servlet/packageinfo
+++ b/portal-impl/src/com/liferay/portal/servlet/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.2
+version 2.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionActivationListener.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionActivationListener.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.kernel.servlet;
 
-import com.liferay.portal.kernel.util.TransientValue;
-
 import java.io.Serializable;
 
 import javax.servlet.http.HttpSession;
@@ -35,26 +33,14 @@ public class PortalSessionActivationListener
 	public static PortalSessionActivationListener getInstance(
 		HttpSession session) {
 
-		TransientValue<PortalSessionActivationListener> transientValue =
-			(TransientValue<PortalSessionActivationListener>)
-				session.getAttribute(
-					PortalSessionActivationListener.class.getName());
-
-		PortalSessionActivationListener portalSessionActivationListener = null;
-
-		if (transientValue != null) {
-			portalSessionActivationListener = transientValue.getValue();
-		}
-
-		return portalSessionActivationListener;
+		return (PortalSessionActivationListener)session.getAttribute(
+			PortalSessionActivationListener.class.getName());
 	}
 
 	public static void setInstance(HttpSession session) {
-		TransientValue<PortalSessionActivationListener> transientValue =
-			new TransientValue<>(PortalSessionActivationListener.getInstance());
-
 		session.setAttribute(
-			PortalSessionActivationListener.class.getName(), transientValue);
+			PortalSessionActivationListener.class.getName(),
+			PortalSessionActivationListener.getInstance());
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionActivationListener.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionActivationListener.java
@@ -45,12 +45,12 @@ public class PortalSessionActivationListener
 
 	@Override
 	public void sessionDidActivate(HttpSessionEvent httpSessionEvent) {
-		PortalSessionCreatorDestroyerUtil.createSession(httpSessionEvent);
+		PortalSessionCreatorDestroyerUtil.activateSession(httpSessionEvent);
 	}
 
 	@Override
 	public void sessionWillPassivate(HttpSessionEvent httpSessionEvent) {
-		PortalSessionCreatorDestroyerUtil.destroySession(httpSessionEvent);
+		PortalSessionCreatorDestroyerUtil.passivateSession(httpSessionEvent);
 	}
 
 	private static final PortalSessionActivationListener _instance =

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionActivationListener.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionActivationListener.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.servlet;
+
+import com.liferay.portal.kernel.util.TransientValue;
+
+import java.io.Serializable;
+
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionActivationListener;
+import javax.servlet.http.HttpSessionEvent;
+
+/**
+ * @author Alexander Chow
+ */
+public class PortalSessionActivationListener
+	implements HttpSessionActivationListener, Serializable {
+
+	public static PortalSessionActivationListener getInstance() {
+		return _instance;
+	}
+
+	public static PortalSessionActivationListener getInstance(
+		HttpSession session) {
+
+		TransientValue<PortalSessionActivationListener> transientValue =
+			(TransientValue<PortalSessionActivationListener>)
+				session.getAttribute(
+					PortalSessionActivationListener.class.getName());
+
+		PortalSessionActivationListener portalSessionActivationListener = null;
+
+		if (transientValue != null) {
+			portalSessionActivationListener = transientValue.getValue();
+		}
+
+		return portalSessionActivationListener;
+	}
+
+	public static void setInstance(HttpSession session) {
+		TransientValue<PortalSessionActivationListener> transientValue =
+			new TransientValue<>(PortalSessionActivationListener.getInstance());
+
+		session.setAttribute(
+			PortalSessionActivationListener.class.getName(), transientValue);
+	}
+
+	@Override
+	public void sessionDidActivate(HttpSessionEvent httpSessionEvent) {
+		PortalSessionCreatorDestroyerUtil.createSession(httpSessionEvent);
+	}
+
+	@Override
+	public void sessionWillPassivate(HttpSessionEvent httpSessionEvent) {
+		PortalSessionCreatorDestroyerUtil.destroySession(httpSessionEvent);
+	}
+
+	private static final PortalSessionActivationListener _instance =
+		new PortalSessionActivationListener();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionCreatorDestroyer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionCreatorDestroyer.java
@@ -25,4 +25,8 @@ public interface PortalSessionCreatorDestroyer {
 
 	public void destroySession(HttpSessionEvent httpSessionEvent);
 
+	public void activateSession(HttpSessionEvent httpSessionEvent);
+
+	public void passivateSession(HttpSessionEvent httpSessionEvent);
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionCreatorDestroyer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionCreatorDestroyer.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.servlet;
+
+import javax.servlet.http.HttpSessionEvent;
+
+/**
+ * @author Preston Crary
+ */
+public interface PortalSessionCreatorDestroyer {
+
+	public void createSession(HttpSessionEvent httpSessionEvent);
+
+	public void destroySession(HttpSessionEvent httpSessionEvent);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionCreatorDestroyerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionCreatorDestroyerUtil.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.servlet;
+
+import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
+
+import javax.servlet.http.HttpSessionEvent;
+
+/**
+ * @author Preston Crary
+ */
+public class PortalSessionCreatorDestroyerUtil {
+
+	public static void createSession(HttpSessionEvent httpSessionEvent) {
+		getPortalSessionCreatorDestroyer().createSession(httpSessionEvent);
+	}
+
+	public static void destroySession(HttpSessionEvent httpSessionEvent) {
+		getPortalSessionCreatorDestroyer().destroySession(httpSessionEvent);
+	}
+
+	public static PortalSessionCreatorDestroyer getPortalSessionCreatorDestroyer() {
+		PortalRuntimePermission.checkGetBeanProperty(
+			PortalSessionCreatorDestroyerUtil.class);
+
+		return _portalSessionCreatorDestroyer;
+	}
+
+	public static void setPortalSessionCreatorDestroyer(
+		PortalSessionCreatorDestroyer portalSessionCreatorDestroyer) {
+
+		PortalRuntimePermission.checkGetBeanProperty(
+			PortalSessionCreatorDestroyerUtil.class);
+
+		_portalSessionCreatorDestroyer = portalSessionCreatorDestroyer;
+	}
+
+	private static PortalSessionCreatorDestroyer _portalSessionCreatorDestroyer;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionCreatorDestroyerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionCreatorDestroyerUtil.java
@@ -31,6 +31,14 @@ public class PortalSessionCreatorDestroyerUtil {
 		getPortalSessionCreatorDestroyer().destroySession(httpSessionEvent);
 	}
 
+	public static void activateSession(HttpSessionEvent httpSessionEvent) {
+		getPortalSessionCreatorDestroyer().activateSession(httpSessionEvent);
+	}
+
+	public static void passivateSession(HttpSessionEvent httpSessionEvent) {
+		getPortalSessionCreatorDestroyer().passivateSession(httpSessionEvent);
+	}
+
 	public static PortalSessionCreatorDestroyer getPortalSessionCreatorDestroyer() {
 		PortalRuntimePermission.checkGetBeanProperty(
 			PortalSessionCreatorDestroyerUtil.class);

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/PortletSessionTracker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/PortletSessionTracker.java
@@ -85,6 +85,14 @@ public class PortletSessionTracker {
 		}
 	}
 
+	public static void passivate(String sessionId) {
+		if (CompoundSessionIdSplitterUtil.hasSessionDelimiter()) {
+			sessionId = CompoundSessionIdSplitterUtil.parseSessionId(sessionId);
+		}
+
+		_sessions.remove(sessionId);
+	}
+
 	private static final ConcurrentMap<String, Map<String, HttpSession>>
 		_sessions = new ConcurrentHashMap<>();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -169,6 +169,7 @@
         portal-kernel/src/com/liferay/portal/kernel/model/impl/VirtualLayout.java@207,\
         portal-kernel/src/com/liferay/portal/kernel/model/impl/VirtualLayout.java@211,\
         portal-kernel/src/com/liferay/portal/kernel/search/QueryConfig.java@379,\
+        portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionCreatorDestroyerUtil.java@34,\
         portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java,\
         portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java,\
         portal-kernel/test/unit/com/liferay/portal/kernel/concurrent/ThreadPoolExecutorTest.java@234,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-65236

Yes this is kind of what I had in mind for the trackers. But it kind of feels like futile as we can't track sessions when they get removed from memory, so I think it can't fully work as we wan't it. And just do something like Live User tracking for sessions.

Also these are not session create/destroy events, the session is live the whole time. So I'm not sure about the channel destroy event, but we shouldn't tell the Live User tracker the user logged out as they still have a live session.

I updated the LPS with minimal reproduction of this behavior for tomcat.

Br,
Norbert