### PR TITLE
[Technical-Support] LPS-67529

### DIFF
--- a/modules/apps/collaboration/bookmarks/bookmarks-service/build.gradle
+++ b/modules/apps/collaboration/bookmarks/bookmarks-service/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"

--- a/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/verify/model/BookmarksEntryVerifiableModel.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/verify/model/BookmarksEntryVerifiableModel.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.bookmarks.internal.verify.model;
+
+import com.liferay.bookmarks.model.BookmarksEntry;
+import com.liferay.portal.kernel.verify.model.VerifiableResourcedModel;
+
+/**
+ * @author Hai Yu
+ */
+public class BookmarksEntryVerifiableModel implements VerifiableResourcedModel {
+
+	@Override
+	public String getModelName() {
+		return BookmarksEntry.class.getName();
+	}
+
+	@Override
+	public String getPrimaryKeyColumnName() {
+		return "entryId";
+	}
+
+	@Override
+	public String getTableName() {
+		return "BookmarksEntry";
+	}
+
+	@Override
+	public String getUserIdColumnName() {
+		return "userId";
+	}
+
+}

--- a/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/verify/model/BookmarksFolderVerifiableModel.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/verify/model/BookmarksFolderVerifiableModel.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.bookmarks.internal.verify.model;
+
+import com.liferay.bookmarks.model.BookmarksFolder;
+import com.liferay.portal.kernel.verify.model.VerifiableResourcedModel;
+
+/**
+ * @author Hai Yu
+ */
+public class BookmarksFolderVerifiableModel
+	implements VerifiableResourcedModel {
+
+	@Override
+	public String getModelName() {
+		return BookmarksFolder.class.getName();
+	}
+
+	@Override
+	public String getPrimaryKeyColumnName() {
+		return "folderId";
+	}
+
+	@Override
+	public String getTableName() {
+		return "BookmarksFolder";
+	}
+
+	@Override
+	public String getUserIdColumnName() {
+		return "userId";
+	}
+
+}

--- a/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/verify/BookmarksServiceVerifyProcess.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/verify/BookmarksServiceVerifyProcess.java
@@ -20,19 +20,11 @@ import com.liferay.bookmarks.service.BookmarksEntryLocalService;
 import com.liferay.bookmarks.service.BookmarksFolderLocalService;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.ResourceBlock;
-import com.liferay.portal.kernel.service.ResourceBlockLocalService;
 import com.liferay.portal.kernel.util.LoggingTimer;
-import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.verify.VerifyProcess;
 
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -52,40 +44,7 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 	protected void doVerify() throws Exception {
 		updateEntryAssets();
 		updateFolderAssets();
-		verifyResourceBlock(
-			BookmarksEntry.class.getName(), "entryId", "BookmarksEntry");
-		verifyResourceBlock(
-			BookmarksFolder.class.getName(), "folderId", "BookmarksFolder");
 		verifyTree();
-	}
-
-	protected Map<Long, String[]> getRoleIdsToActionIds(
-			String modelName, long resourceBlockId)
-		throws Exception {
-
-		try (PreparedStatement ps1 = connection.prepareStatement(
-				"select roleId, actionIds from ResourceBlockPermission where " +
-					"resourceBlockId = " + resourceBlockId);
-			ResultSet rs1 = ps1.executeQuery()) {
-
-			Map<Long, String[]> roleIdsToActionIds = new HashMap<>();
-
-			for (int i = 0; rs1.next(); i++) {
-				long roleId = rs1.getLong("roleId");
-				long actionIds = rs1.getLong("actionIds");
-
-				List<String> definedActionIds =
-					_resourceBlockLocalService.getActionIds(
-						modelName, actionIds);
-
-				roleIdsToActionIds.put(
-					roleId,
-					definedActionIds.toArray(
-						new String[definedActionIds.size()]));
-			}
-
-			return roleIdsToActionIds;
-		}
 	}
 
 	@Reference(unbind = "-")
@@ -100,13 +59,6 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 		BookmarksFolderLocalService bookmarksFolderLocalService) {
 
 		_bookmarksFolderLocalService = bookmarksFolderLocalService;
-	}
-
-	@Reference(unbind = "-")
-	protected void setResourceBlockLocalService(
-		ResourceBlockLocalService resourceBlockLocalService) {
-
-		_resourceBlockLocalService = resourceBlockLocalService;
 	}
 
 	protected void updateEntryAssets() throws Exception {
@@ -169,113 +121,6 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 		}
 	}
 
-	protected void updateResourceBlock(
-			String modelName, long referenceCount, long resourceBlockId,
-			String resourcePrimKey, Map<Long, String[]> roleIdsToActionIds,
-			String tableName)
-		throws Exception {
-
-		try (PreparedStatement ps1 = connection.prepareStatement(
-				"select companyId, groupId, " + resourcePrimKey + " from " +
-					tableName + " where " + "resourceBlockId = " +
-						resourceBlockId + " order by modifiedDate desc");
-			ResultSet rs1 = ps1.executeQuery()) {
-
-			for (int i = 0; rs1.next(); i++) {
-				long companyId = rs1.getLong("companyId");
-				long groupId = rs1.getLong("groupId");
-				long tableResourcePrimKey = rs1.getLong(resourcePrimKey);
-
-				_resourceBlockLocalService.setIndividualScopePermissions(
-					companyId, groupId, modelName, tableResourcePrimKey,
-					roleIdsToActionIds);
-
-				long newResourceBlockId;
-
-				if (modelName.equals(BookmarksEntry.class.getName())) {
-					BookmarksEntry bookmarksEntry =
-						_bookmarksEntryLocalService.fetchBookmarksEntry(
-							tableResourcePrimKey);
-
-					newResourceBlockId = bookmarksEntry.getResourceBlockId();
-				}
-				else {
-					BookmarksFolder bookmarksFolder =
-						_bookmarksFolderLocalService.fetchBookmarksFolder(
-							tableResourcePrimKey);
-
-					newResourceBlockId = bookmarksFolder.getResourceBlockId();
-				}
-
-				PreparedStatement ps2 = connection.prepareStatement(
-					"update " + tableName + " set resourceBlockId = ?" +
-						" where resourceBlockId = ?");
-
-				ps2.setLong(1, newResourceBlockId);
-				ps2.setLong(2, resourceBlockId);
-
-				ps2.executeUpdate();
-
-				ResourceBlock resourceBlock =
-					_resourceBlockLocalService.fetchResourceBlock(
-						newResourceBlockId);
-
-				resourceBlock.setReferenceCount(referenceCount);
-
-				_resourceBlockLocalService.updateResourceBlock(resourceBlock);
-
-				break;
-			}
-		}
-	}
-
-	protected void verifyResourceBlock(
-			String modelName, String resourcePrimKey, String tableName)
-		throws Exception {
-
-		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			StringBundler sb = new StringBundler(8);
-
-			sb.append("select t.* from (select resourceBlockId, ");
-			sb.append("count(resourceBlockId) as total from ");
-			sb.append(tableName);
-			sb.append(" group by resourceBlockId) t left join ");
-			sb.append("ResourceBlock on ");
-			sb.append("(ResourceBlock.resourceBlockId = t.resourceBlockId) ");
-			sb.append("and (ResourceBlock.referenceCount = t.total) ");
-			sb.append("where ResourceBlock.resourceBlockId is null");
-
-			try (PreparedStatement ps = connection.prepareStatement(
-					sb.toString());
-				ResultSet rs = ps.executeQuery()) {
-
-				while (rs.next()) {
-					long resourceBlockId = rs.getLong("resourceBlockId");
-					long referenceCount = rs.getLong("total");
-
-					ResourceBlock resourceBlock =
-						_resourceBlockLocalService.fetchResourceBlock(
-							resourceBlockId);
-
-					if (resourceBlock == null) {
-						Map<Long, String[]> roleIdsToActionIds =
-							getRoleIdsToActionIds(modelName, resourceBlockId);
-
-						updateResourceBlock(
-							modelName, referenceCount, resourceBlockId,
-							resourcePrimKey, roleIdsToActionIds, tableName);
-					}
-					else {
-						resourceBlock.setReferenceCount(referenceCount);
-
-						_resourceBlockLocalService.updateResourceBlock(
-							resourceBlock);
-					}
-				}
-			}
-		}
-	}
-
 	protected void verifyTree() throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
@@ -291,6 +136,5 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 
 	private BookmarksEntryLocalService _bookmarksEntryLocalService;
 	private BookmarksFolderLocalService _bookmarksFolderLocalService;
-	private ResourceBlockLocalService _resourceBlockLocalService;
 
 }

--- a/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/verify/BookmarksServiceVerifyProcess.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/verify/BookmarksServiceVerifyProcess.java
@@ -14,6 +14,8 @@
 
 package com.liferay.bookmarks.verify;
 
+import com.liferay.bookmarks.internal.verify.model.BookmarksEntryVerifiableModel;
+import com.liferay.bookmarks.internal.verify.model.BookmarksFolderVerifiableModel;
 import com.liferay.bookmarks.model.BookmarksEntry;
 import com.liferay.bookmarks.model.BookmarksFolder;
 import com.liferay.bookmarks.service.BookmarksEntryLocalService;
@@ -23,6 +25,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.verify.VerifyProcess;
+import com.liferay.portal.verify.VerifyResourceBlock;
 
 import java.util.List;
 
@@ -44,6 +47,7 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 	protected void doVerify() throws Exception {
 		updateEntryAssets();
 		updateFolderAssets();
+		verifyResourcedModels();
 		verifyTree();
 	}
 
@@ -121,6 +125,13 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 		}
 	}
 
+	protected void verifyResourcedModels() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			_verifyResourceBlock.verify(new BookmarksEntryVerifiableModel());
+			_verifyResourceBlock.verify(new BookmarksFolderVerifiableModel());
+		}
+	}
+
 	protected void verifyTree() throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
@@ -136,5 +147,7 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 
 	private BookmarksEntryLocalService _bookmarksEntryLocalService;
 	private BookmarksFolderLocalService _bookmarksFolderLocalService;
+	private final VerifyResourceBlock _verifyResourceBlock =
+		new VerifyResourceBlock();
 
 }

--- a/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/verify/BookmarksServiceVerifyProcess.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/verify/BookmarksServiceVerifyProcess.java
@@ -20,11 +20,19 @@ import com.liferay.bookmarks.service.BookmarksEntryLocalService;
 import com.liferay.bookmarks.service.BookmarksFolderLocalService;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ResourceBlock;
+import com.liferay.portal.kernel.service.ResourceBlockLocalService;
 import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.verify.VerifyProcess;
 
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -44,7 +52,40 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 	protected void doVerify() throws Exception {
 		updateEntryAssets();
 		updateFolderAssets();
+		verifyResourceBlock(
+			BookmarksEntry.class.getName(), "entryId", "BookmarksEntry");
+		verifyResourceBlock(
+			BookmarksFolder.class.getName(), "folderId", "BookmarksFolder");
 		verifyTree();
+	}
+
+	protected Map<Long, String[]> getRoleIdsToActionIds(
+			String modelName, long resourceBlockId)
+		throws Exception {
+
+		try (PreparedStatement ps1 = connection.prepareStatement(
+				"select roleId, actionIds from ResourceBlockPermission where " +
+					"resourceBlockId = " + resourceBlockId);
+			ResultSet rs1 = ps1.executeQuery()) {
+
+			Map<Long, String[]> roleIdsToActionIds = new HashMap<>();
+
+			for (int i = 0; rs1.next(); i++) {
+				long roleId = rs1.getLong("roleId");
+				long actionIds = rs1.getLong("actionIds");
+
+				List<String> definedActionIds =
+					_resourceBlockLocalService.getActionIds(
+						modelName, actionIds);
+
+				roleIdsToActionIds.put(
+					roleId,
+					definedActionIds.toArray(
+						new String[definedActionIds.size()]));
+			}
+
+			return roleIdsToActionIds;
+		}
 	}
 
 	@Reference(unbind = "-")
@@ -59,6 +100,13 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 		BookmarksFolderLocalService bookmarksFolderLocalService) {
 
 		_bookmarksFolderLocalService = bookmarksFolderLocalService;
+	}
+
+	@Reference(unbind = "-")
+	protected void setResourceBlockLocalService(
+		ResourceBlockLocalService resourceBlockLocalService) {
+
+		_resourceBlockLocalService = resourceBlockLocalService;
 	}
 
 	protected void updateEntryAssets() throws Exception {
@@ -121,6 +169,113 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 		}
 	}
 
+	protected void updateResourceBlock(
+			String modelName, long referenceCount, long resourceBlockId,
+			String resourcePrimKey, Map<Long, String[]> roleIdsToActionIds,
+			String tableName)
+		throws Exception {
+
+		try (PreparedStatement ps1 = connection.prepareStatement(
+				"select companyId, groupId, " + resourcePrimKey + " from " +
+					tableName + " where " + "resourceBlockId = " +
+						resourceBlockId + " order by modifiedDate desc");
+			ResultSet rs1 = ps1.executeQuery()) {
+
+			for (int i = 0; rs1.next(); i++) {
+				long companyId = rs1.getLong("companyId");
+				long groupId = rs1.getLong("groupId");
+				long tableResourcePrimKey = rs1.getLong(resourcePrimKey);
+
+				_resourceBlockLocalService.setIndividualScopePermissions(
+					companyId, groupId, modelName, tableResourcePrimKey,
+					roleIdsToActionIds);
+
+				long newResourceBlockId;
+
+				if (modelName.equals(BookmarksEntry.class.getName())) {
+					BookmarksEntry bookmarksEntry =
+						_bookmarksEntryLocalService.fetchBookmarksEntry(
+							tableResourcePrimKey);
+
+					newResourceBlockId = bookmarksEntry.getResourceBlockId();
+				}
+				else {
+					BookmarksFolder bookmarksFolder =
+						_bookmarksFolderLocalService.fetchBookmarksFolder(
+							tableResourcePrimKey);
+
+					newResourceBlockId = bookmarksFolder.getResourceBlockId();
+				}
+
+				PreparedStatement ps2 = connection.prepareStatement(
+					"update " + tableName + " set resourceBlockId = ?" +
+						" where resourceBlockId = ?");
+
+				ps2.setLong(1, newResourceBlockId);
+				ps2.setLong(2, resourceBlockId);
+
+				ps2.executeUpdate();
+
+				ResourceBlock resourceBlock =
+					_resourceBlockLocalService.fetchResourceBlock(
+						newResourceBlockId);
+
+				resourceBlock.setReferenceCount(referenceCount);
+
+				_resourceBlockLocalService.updateResourceBlock(resourceBlock);
+
+				break;
+			}
+		}
+	}
+
+	protected void verifyResourceBlock(
+			String modelName, String resourcePrimKey, String tableName)
+		throws Exception {
+
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			StringBundler sb = new StringBundler(8);
+
+			sb.append("select t.* from (select resourceBlockId, ");
+			sb.append("count(resourceBlockId) as total from ");
+			sb.append(tableName);
+			sb.append(" group by resourceBlockId) t left join ");
+			sb.append("ResourceBlock on ");
+			sb.append("(ResourceBlock.resourceBlockId = t.resourceBlockId) ");
+			sb.append("and (ResourceBlock.referenceCount = t.total) ");
+			sb.append("where ResourceBlock.resourceBlockId is null");
+
+			try (PreparedStatement ps = connection.prepareStatement(
+					sb.toString());
+				ResultSet rs = ps.executeQuery()) {
+
+				while (rs.next()) {
+					long resourceBlockId = rs.getLong("resourceBlockId");
+					long referenceCount = rs.getLong("total");
+
+					ResourceBlock resourceBlock =
+						_resourceBlockLocalService.fetchResourceBlock(
+							resourceBlockId);
+
+					if (resourceBlock == null) {
+						Map<Long, String[]> roleIdsToActionIds =
+							getRoleIdsToActionIds(modelName, resourceBlockId);
+
+						updateResourceBlock(
+							modelName, referenceCount, resourceBlockId,
+							resourcePrimKey, roleIdsToActionIds, tableName);
+					}
+					else {
+						resourceBlock.setReferenceCount(referenceCount);
+
+						_resourceBlockLocalService.updateResourceBlock(
+							resourceBlock);
+					}
+				}
+			}
+		}
+	}
+
 	protected void verifyTree() throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
 			long[] companyIds = PortalInstances.getCompanyIdsBySQL();
@@ -136,5 +291,6 @@ public class BookmarksServiceVerifyProcess extends VerifyProcess {
 
 	private BookmarksEntryLocalService _bookmarksEntryLocalService;
 	private BookmarksFolderLocalService _bookmarksFolderLocalService;
+	private ResourceBlockLocalService _resourceBlockLocalService;
 
 }

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/build.gradle
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.rss.util", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay", name: "net.fortuna.ical4j", version: "1.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "javax.mail", name: "mail", version: "1.4"

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/verify/model/CalendarBookingVerifiableModel.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/verify/model/CalendarBookingVerifiableModel.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.verify.model;
+
+import com.liferay.calendar.model.CalendarBooking;
+import com.liferay.portal.kernel.verify.model.VerifiableResourcedModel;
+
+/**
+ * @author Hai Yu
+ */
+public class CalendarBookingVerifiableModel
+	implements VerifiableResourcedModel {
+
+	@Override
+	public String getModelName() {
+		return CalendarBooking.class.getName();
+	}
+
+	@Override
+	public String getPrimaryKeyColumnName() {
+		return "calendarBookingId";
+	}
+
+	@Override
+	public String getTableName() {
+		return "CalendarBooking";
+	}
+
+	@Override
+	public String getUserIdColumnName() {
+		return "userId";
+	}
+
+}

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/verify/model/CalendarResourceVerifiableModel.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/verify/model/CalendarResourceVerifiableModel.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.verify.model;
+
+import com.liferay.calendar.model.CalendarResource;
+import com.liferay.portal.kernel.verify.model.VerifiableResourcedModel;
+
+/**
+ * @author Hai Yu
+ */
+public class CalendarResourceVerifiableModel
+	implements VerifiableResourcedModel {
+
+	@Override
+	public String getModelName() {
+		return CalendarResource.class.getName();
+	}
+
+	@Override
+	public String getPrimaryKeyColumnName() {
+		return "calendarResourceId";
+	}
+
+	@Override
+	public String getTableName() {
+		return "CalendarResource";
+	}
+
+	@Override
+	public String getUserIdColumnName() {
+		return "userId";
+	}
+
+}

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/verify/model/CalendarVerifiableModel.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/verify/model/CalendarVerifiableModel.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.verify.model;
+
+import com.liferay.calendar.model.Calendar;
+import com.liferay.portal.kernel.verify.model.VerifiableResourcedModel;
+
+/**
+ * @author Hai Yu
+ */
+public class CalendarVerifiableModel implements VerifiableResourcedModel {
+
+	@Override
+	public String getModelName() {
+		return Calendar.class.getName();
+	}
+
+	@Override
+	public String getPrimaryKeyColumnName() {
+		return "calendarId";
+	}
+
+	@Override
+	public String getTableName() {
+		return "Calendar";
+	}
+
+	@Override
+	public String getUserIdColumnName() {
+		return "userId";
+	}
+
+}

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/verify/CalendarServiceVerifyProcess.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/verify/CalendarServiceVerifyProcess.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.verify;
+
+import com.liferay.calendar.internal.verify.model.CalendarBookingVerifiableModel;
+import com.liferay.calendar.internal.verify.model.CalendarResourceVerifiableModel;
+import com.liferay.calendar.internal.verify.model.CalendarVerifiableModel;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.verify.VerifyProcess;
+import com.liferay.portal.verify.VerifyResourceBlock;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Hai Yu
+ */
+@Component(
+	immediate = true,
+	property = {"verify.process.name=com.liferay.calendar.service"},
+	service = VerifyProcess.class
+)
+public class CalendarServiceVerifyProcess extends VerifyProcess {
+
+	@Override
+	protected void doVerify() throws Exception {
+		verifyResourcedModels();
+	}
+
+	protected void verifyResourcedModels() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			_verifyResourceBlock.verify(new CalendarVerifiableModel());
+			_verifyResourceBlock.verify(new CalendarBookingVerifiableModel());
+			_verifyResourceBlock.verify(new CalendarResourceVerifiableModel());
+		}
+	}
+
+	private final VerifyResourceBlock _verifyResourceBlock =
+		new VerifyResourceBlock();
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourceBlockLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourceBlockLocalServiceImpl.java
@@ -417,10 +417,6 @@ public class ResourceBlockLocalServiceImpl
 	}
 
 	@Override
-	@Transactional(
-		isolation = Isolation.READ_COMMITTED,
-		propagation = Propagation.REQUIRES_NEW
-	)
 	public void releasePermissionedModelResourceBlock(
 		PermissionedModel permissionedModel) {
 
@@ -445,10 +441,6 @@ public class ResourceBlockLocalServiceImpl
 	 * @param resourceBlockId the primary key of the resource block
 	 */
 	@Override
-	@Transactional(
-		isolation = Isolation.READ_COMMITTED,
-		propagation = Propagation.REQUIRES_NEW
-	)
 	public void releaseResourceBlock(long resourceBlockId) {
 		Session session = resourceBlockPersistence.openSession();
 

--- a/portal-impl/src/com/liferay/portal/verify/VerifyResourceBlock.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyResourceBlock.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.verify;
+
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.model.ResourceBlock;
+import com.liferay.portal.kernel.service.ResourceBlockLocalServiceUtil;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.verify.model.VerifiableResourcedModel;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Hai Yu
+ */
+public class VerifyResourceBlock extends VerifyProcess {
+
+	public void verify(VerifiableResourcedModel verifiableResourcedModel)
+		throws Exception {
+
+		verifyResourceBlock(
+			verifiableResourcedModel.getModelName(),
+			verifiableResourcedModel.getPrimaryKeyColumnName(),
+			verifiableResourcedModel.getTableName());
+	}
+
+	protected void doVerify() throws Exception {
+	}
+
+	protected long[] getNewResourceBlockIdAndReferenceCount(
+			String primKey, long tablePrimKey, String tableName)
+		throws Exception {
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append("select resourceBlockId, referenceCount from ResourceBlock ");
+		sb.append("where resourceBlockId in (select resourceBlockId from ");
+		sb.append(tableName);
+		sb.append(" where ");
+		sb.append(primKey);
+		sb.append(" = ");
+		sb.append(tablePrimKey);
+		sb.append(")");
+
+		try (Connection con = DataAccess.getUpgradeOptimizedConnection();
+			PreparedStatement ps = con.prepareStatement(sb.toString());
+			ResultSet rs = ps.executeQuery()) {
+
+			long[] newResourceBlockIdAndReferenceCount = new long[2];
+
+			while (rs.next()) {
+				newResourceBlockIdAndReferenceCount[0] = rs.getLong(
+					"resourceBlockId");
+				newResourceBlockIdAndReferenceCount[1] = rs.getLong(
+					"referenceCount");
+			}
+
+			return newResourceBlockIdAndReferenceCount;
+		}
+	}
+
+	protected Map<Long, String[]> getRoleIdsToActionIds(
+			String modelName, long resourceBlockId)
+		throws Exception {
+
+		try (Connection con = DataAccess.getUpgradeOptimizedConnection();
+			PreparedStatement ps = con.prepareStatement(
+				"select roleId, actionIds from ResourceBlockPermission where " +
+					"resourceBlockId = " + resourceBlockId);
+			ResultSet rs = ps.executeQuery()) {
+
+			Map<Long, String[]> roleIdsToActionIds = new HashMap<>();
+
+			for (int i = 0; rs.next(); i++) {
+				long roleId = rs.getLong("roleId");
+				long actionIds = rs.getLong("actionIds");
+
+				List<String> definedActionIds =
+					ResourceBlockLocalServiceUtil.getActionIds(
+						modelName, actionIds);
+
+				roleIdsToActionIds.put(
+					roleId,
+					definedActionIds.toArray(
+						new String[definedActionIds.size()]));
+			}
+
+			return roleIdsToActionIds;
+		}
+	}
+
+	protected void updateResourceBlock(
+			String modelName, long referenceCount, long resourceBlockId,
+			String primKey, Map<Long, String[]> roleIdsToActionIds,
+			String tableName)
+		throws Exception {
+
+		try (Connection con = DataAccess.getUpgradeOptimizedConnection();
+			PreparedStatement ps1 = con.prepareStatement(
+				"select companyId, groupId, " + primKey + " from " + tableName +
+					" where " + "resourceBlockId = " + resourceBlockId +
+						" order by modifiedDate desc");
+			ResultSet rs1 = ps1.executeQuery()) {
+
+			for (int i = 0; rs1.next(); i++) {
+				long companyId = rs1.getLong("companyId");
+				long groupId = rs1.getLong("groupId");
+				long tablePrimKey = rs1.getLong(primKey);
+
+				ResourceBlockLocalServiceUtil.setIndividualScopePermissions(
+					companyId, groupId, modelName, tablePrimKey,
+					roleIdsToActionIds);
+
+				long[] newResourceBlockIdAndReferenceCount =
+					getNewResourceBlockIdAndReferenceCount(
+						primKey, tablePrimKey, tableName);
+
+				PreparedStatement ps2 = con.prepareStatement(
+					"update " + tableName + " set resourceBlockId = ?" +
+						" where resourceBlockId = ?");
+
+				ps2.setLong(1, newResourceBlockIdAndReferenceCount[0]);
+				ps2.setLong(2, resourceBlockId);
+
+				ps2.executeUpdate();
+
+				ResourceBlock resourceBlock =
+					ResourceBlockLocalServiceUtil.fetchResourceBlock(
+						newResourceBlockIdAndReferenceCount[0]);
+
+				referenceCount =
+					newResourceBlockIdAndReferenceCount[1] + referenceCount - 1;
+
+				resourceBlock.setReferenceCount(referenceCount);
+
+				ResourceBlockLocalServiceUtil.updateResourceBlock(
+					resourceBlock);
+
+				break;
+			}
+		}
+	}
+
+	protected void verifyResourceBlock(
+			String modelName, String primKey, String tableName)
+		throws Exception {
+
+		try (LoggingTimer loggingTimer = new LoggingTimer(tableName)) {
+			StringBundler sb = new StringBundler(8);
+
+			sb.append("select t.* from (select resourceBlockId, ");
+			sb.append("count(resourceBlockId) as total from ");
+			sb.append(tableName);
+			sb.append(" group by resourceBlockId) t left join ");
+			sb.append("ResourceBlock on ");
+			sb.append("(ResourceBlock.resourceBlockId = t.resourceBlockId) ");
+			sb.append("and (ResourceBlock.referenceCount = t.total) ");
+			sb.append("where ResourceBlock.resourceBlockId is null");
+
+			try (Connection con = DataAccess.getUpgradeOptimizedConnection();
+				PreparedStatement ps = con.prepareStatement(sb.toString());
+				ResultSet rs = ps.executeQuery()) {
+
+				while (rs.next()) {
+					long resourceBlockId = rs.getLong("resourceBlockId");
+					long referenceCount = rs.getLong("total");
+
+					ResourceBlock resourceBlock =
+						ResourceBlockLocalServiceUtil.fetchResourceBlock(
+							resourceBlockId);
+
+					if (resourceBlock == null) {
+						Map<Long, String[]> roleIdsToActionIds =
+							getRoleIdsToActionIds(modelName, resourceBlockId);
+
+						updateResourceBlock(
+							modelName, referenceCount, resourceBlockId, primKey,
+							roleIdsToActionIds, tableName);
+					}
+					else {
+						resourceBlock.setReferenceCount(referenceCount);
+
+						ResourceBlockLocalServiceUtil.updateResourceBlock(
+							resourceBlock);
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourceBlockLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourceBlockLocalService.java
@@ -339,7 +339,6 @@ public interface ResourceBlockLocalService extends BaseLocalService,
 		java.lang.String name, long primKey, long roleId, long actionIdsLong)
 		throws PortalException;
 
-	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
 	public void releasePermissionedModelResourceBlock(
 		PermissionedModel permissionedModel);
 
@@ -363,7 +362,6 @@ public interface ResourceBlockLocalService extends BaseLocalService,
 	*
 	* @param resourceBlockId the primary key of the resource block
 	*/
-	@Transactional(isolation = Isolation.READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
 	public void releaseResourceBlock(long resourceBlockId);
 
 	public void removeAllGroupScopePermissions(long companyId,

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -291,6 +291,7 @@
         portal-impl/src/com/liferay/portal/upgrade/util/BaseUpgradeTableImpl.java,\
         portal-impl/src/com/liferay/portal/upgrade/util/UpgradeCompanyId.java,\
         portal-impl/src/com/liferay/portal/verify/VerifyProcess.java,\
+        portal-impl/src/com/liferay/portal/verify/VerifyResourceBlock.java,\
         portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradeCompanyId.java,\
         portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java,\
         portal-kernel/src/com/liferay/portal/kernel/upgrade/util/UpgradeProcessUtil.java


### PR DESCRIPTION
Hi Preston,

I hope your are well.

cc @daledotshan 

This PR extends from https://github.com/Preston-Crary/liferay-portal/pull/148

**Root issue:**
The issue is caused by part fix of LPS-28276.

When execute one delete command(including delete different models(bookmarks,dlfileentry, mbthreads) or some bookmark entrys, for example, auto-clean Recycle Bin: CheckEntryMessageListener execute:), if this delete failed and bookmarks delete logic has been executed, our resourceBlock table data won't be rolled back. This will affect bookmarks permission.

**Verfiy explanation:**
Only resourceBlock data is lost and its actually permission is existed in resourceblockpermission.
I assume there are 10 BookmarksFolder and they are using same resourceBlockId. The unclean data includes two kinds:
1. 10 datas are in Recycle Bin and they are all deleted( resourceBlock data is removed in resourceBlock table). This logic updateResourceBlock() will take care it.
2. 5 datas are in Recycle Bin and they are deleted  (resourceBlock data's referenceCount will be 5 in resourceBlock table, the normal value is 10). This logic (https://github.com/yuhai/liferay-portal/blob/4a0bddd647db9b90b02a20b0c562868dc1b5d2c9/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/verify/BookmarksServiceVerifyProcess.java#L269-L274) will take care it.

For test, I don't have good way to express this. Because once ResourceBlockLocalServiceUtil execute, even though without fix, the commit will take effect.

Could you please firstly check the verify way is ok for you?

Regards,
Hai

