### PR TITLE
LPS-68289 Add JVM arg to disable memory mapping when reading zip/jar …

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -784,6 +784,7 @@ Error-Prone was automatically installed. Please rerun your task.
 				<jvmarg value="-Djava.net.preferIPv4Stack=true" />
 				<jvmarg value="-Dliferay.log.dir=${liferay.home}/logs" />
 				<jvmarg value="-Dliferay.mode=test" />
+				<jvmarg value="-Dsun.zip.disableMemoryMapping=true" />
 				<jvmarg value="-Dosgi.state.dir=${liferay.home}/osgi/state" />
 				<jvmarg value="-Drelease.versions.test.other.dir=${release.versions.test.other.dir}" />
 				<misc />

--- a/build-test.xml
+++ b/build-test.xml
@@ -2751,7 +2751,7 @@ go</echo>
 						<![CDATA[
 							JMX_OPTS="${testable.tomcat.jmx.opts}"
 
-							CATALINA_OPTS="${CATALINA_OPTS} ${JMX_OPTS}"
+							CATALINA_OPTS="${CATALINA_OPTS} ${JMX_OPTS} -Dsun.zip.disableMemoryMapping=true"
 						]]>
 					</echo>
 				</then>

--- a/portal-impl/src/com/liferay/portal/util/InitUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/InitUtil.java
@@ -32,9 +32,11 @@ import com.liferay.portal.kernel.util.ClassLoaderUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.OSDetector;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PortalLifecycle;
 import com.liferay.portal.kernel.util.PortalLifecycleUtil;
+import com.liferay.portal.kernel.util.ReflectionUtil;
 import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.SystemProperties;
@@ -52,9 +54,12 @@ import com.liferay.util.log4j.Log4JUtil;
 
 import com.sun.syndication.io.XmlReader;
 
+import java.lang.reflect.Field;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipFile;
 
 import org.apache.commons.lang.time.StopWatch;
 
@@ -69,6 +74,22 @@ public class InitUtil {
 	public static synchronized void init() {
 		if (_initialized) {
 			return;
+		}
+
+		try {
+			if (!OSDetector.isWindows()) {
+				Field field = ReflectionUtil.getDeclaredField(
+					ZipFile.class, "usemmap");
+
+				field.setAccessible(true);
+
+				if ((boolean)field.get(null)) {
+					field.setBoolean(null, false);
+				}
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
 		}
 
 		StopWatch stopWatch = new StopWatch();

--- a/portal-impl/test/integration/com/liferay/counter/service/CounterLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/counter/service/CounterLocalServiceTest.java
@@ -130,6 +130,7 @@ public class CounterLocalServiceTest {
 		List<String> arguments = new ArrayList<>();
 
 		arguments.add("-Dliferay.mode=test");
+		arguments.add("-Dsun.zip.disableMemoryMapping=true");
 
 		for (String property :
 				HypersonicServerTestRule.INSTANCE.getJdbcProperties()) {

--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
@@ -125,6 +125,7 @@ public class PACLAggregateTest extends AutoBalanceTestCase {
 		arguments.add("-Djava.security.policy==" + url.getFile());
 
 		arguments.add("-Dliferay.mode=test");
+		arguments.add("-Dsun.zip.disableMemoryMapping=true");
 
 		boolean junitDebug = Boolean.getBoolean("jvm.debug");
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/process/local/LocalProcessExecutorTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/process/local/LocalProcessExecutorTest.java
@@ -1481,6 +1481,7 @@ public class LocalProcessExecutorTest {
 		arguments.add(
 			"-D" + SystemProperties.SYSTEM_PROPERTIES_QUIET + "=true");
 		arguments.add("-Dliferay.mode=test");
+		arguments.add("-Dsun.zip.disableMemoryMapping=true");
 
 		if (Boolean.getBoolean("jvm.debug")) {
 			arguments.add(jpdaOptions);

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/NewEnvTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/NewEnvTestRule.java
@@ -173,6 +173,7 @@ public class NewEnvTestRule implements TestRule {
 		}
 
 		arguments.add("-Dliferay.mode=test");
+		arguments.add("-Dsun.zip.disableMemoryMapping=true");
 
 		String whipAgentLine = System.getProperty("whip.agent");
 


### PR DESCRIPTION
…files, this can cause a fatal error crashing the JVM. Windows has a file lock when reading files so this property is not required on Windows and has no effect.