### PR TITLE
LPS-71009 Always ensure that the process exits so that it does not hang indefinitely

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/process/local/LocalProcessLauncher.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/process/local/LocalProcessLauncher.java
@@ -127,6 +127,8 @@ public class LocalProcessLauncher {
 				new ReturnProcessCallable<Serializable>(result));
 
 			outProcessOutputStream.flush();
+
+			System.exit(0);
 		}
 		catch (Throwable t) {
 			errPrintStream.flush();
@@ -144,6 +146,8 @@ public class LocalProcessLauncher {
 				new ExceptionProcessCallable(processException));
 
 			errProcessOutputStream.flush();
+
+			System.exit(1);
 		}
 		finally {
 			currentThread.setContextClassLoader(contextClassLoader);


### PR DESCRIPTION
Hey @Preston-Crary,

The crux of this issue is that it seems Xuggler spawns a non-daemon thread that causes the entire process to hang indefinitely. Minhchau and I want to make our process executor a bit more friendly and whenever it is done executing, be sure to end the process.

Let me know what you think and if you want to see the issue in action.