### PR TITLE
[Technical Support] LPS-76720 Use encoded version of friendly URL to cover the case where the URL contains special characters

### DIFF
--- a/modules/apps/foundation/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/foundation/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.PortalMessages;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.struts.LastPath;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
@@ -220,9 +221,13 @@ public class FriendlyURLServlet extends HttpServlet {
 				}
 
 				if (localeUnavailable ||
-					!StringUtil.equalsIgnoreCase(
+					(!StringUtil.equalsIgnoreCase(
 						layoutFriendlyURLSeparatorCompositeFriendlyURL,
-						layout.getFriendlyURL(locale)) ||
+						layout.getFriendlyURL(locale)) &&
+					 !StringUtil.equalsIgnoreCase(
+						 FriendlyURLNormalizerUtil.normalizeWithEncoding(
+							 layoutFriendlyURLSeparatorCompositeFriendlyURL),
+						 layout.getFriendlyURL(locale))) ||
 					(alternativeSiteFriendlyURL != null)) {
 
 					Locale originalLocale = setAlternativeLayoutFriendlyURL(

--- a/modules/apps/web-experience/journal/.gitrepo
+++ b/modules/apps/web-experience/journal/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = true
 	cmdver = liferay
-	commit = 34240a2511249958c50402af45df35b3cd651e6a
+	commit = 645e50e3f2c98d8582f04b2f755eb706bfb3cca6
 	mergebuttonmergecommits = false
 	mode = pull
-	parent = 14415fd0b53e7aaf48d1e5e778ff2cab26d87101
+	parent = 37506d2d4c14910d68c97959c48788a4d8558751
 	remote = git@github.com:liferay/com-liferay-journal.git

--- a/modules/apps/web-experience/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-comments/build.gradle
+++ b/modules/apps/web-experience/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-comments/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	provided group: "com.liferay", name: "com.liferay.comment.taglib", version: "1.0.0-20170419.190105-1"
 	provided group: "com.liferay", name: "com.liferay.frontend.taglib", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.petra.lang", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"

--- a/modules/apps/web-experience/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-comments/src/main/resources/META-INF/resources/comments.jsp
+++ b/modules/apps/web-experience/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-comments/src/main/resources/META-INF/resources/comments.jsp
@@ -16,7 +16,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+<%@ taglib uri="http://liferay.com/tld/comment" prefix="liferay-comment" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.journal.content.asset.addon.entry.comments.internal.CommentsContentMetadataAssetAddonEntry" %><%@
@@ -43,7 +44,7 @@ String viewMode = ParamUtil.getString(request, "viewMode");
 		/>
 	</c:if>
 
-	<liferay-ui:discussion
+	<liferay-comment:discussion
 		className="<%= JournalArticle.class.getName() %>"
 		classPK="<%= articleDisplay.getResourcePrimKey() %>"
 		hideControls="<%= viewMode.equals(Constants.PRINT) %>"


### PR DESCRIPTION
## Relevant issues
https://issues.liferay.com/browse/LPS-76720

## Additional details
I've observed that if you make a request to `es/informa%C3%A7%C3%A3o` no redirection loop occurs and the page is shown. If you make a request to `es/web/guest/informa%C3%A7%C3%A3o` then the redirection loop occurs. Here's why it is happening.

In the first case `/informa%C3%A7%C3%A3o` (without the language part) is currently considered for Liferay Portal a valid friendly url. In the second case, `/web/guest/informa%C3%A7%C3%A3o` isn't. Internally it means that the first request will be forwarded internally by a `RequestDispatcher` to a given URL (which will be built with data from the LayoutSet database and the request URI). It also means that the request will be wrapped as a `ApplicatinoHttpRequest` by the dispatcher and its path info value will be percent encoded (as the forward URL). In the second case, the request will be a `RequestFacade` with no wrapping. So its path info value will be the default (decoded).