### PR TITLE
[TS] LPS-74272 URLs are not well generated when locale.prepend.friendly.url.style=2

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1381,17 +1381,48 @@ public class PortalImpl implements Portal {
 			layout.getLayoutSet(), themeDisplay, true,
 			layout.isTypeControlPanel());
 
+		String groupFriendlyURLDomain = HttpUtil.getDomain(groupFriendlyURL);
+
+		int pos = groupFriendlyURL.indexOf(groupFriendlyURLDomain);
+
+		if (pos > 0) {
+			pos = groupFriendlyURL.indexOf(
+				CharPool.SLASH, pos + groupFriendlyURLDomain.length());
+
+			if (Validator.isNotNull(_pathContext)) {
+				pos = groupFriendlyURL.indexOf(
+					CharPool.SLASH, pos + _pathContext.length());
+			}
+		}
+
+		boolean rootURL = false;
+
+		if ((pos <= 0) || (pos >= groupFriendlyURL.length())) {
+			rootURL = true;
+		}
+
 		if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
-			StringBundler sb = new StringBundler(4);
+			if (rootURL) {
+				groupFriendlyURL += buildI18NPath(siteDefaultLocale);
 
-			sb.append(groupFriendlyURL);
-			sb.append(
-				_buildI18NPath(
-					siteDefaultLocale.getLanguage(), siteDefaultLocale));
-			sb.append(canonicalLayoutFriendlyURL);
-			sb.append(parametersURL);
+				if (!canonicalLayoutFriendlyURL.startsWith(StringPool.SLASH)) {
+					groupFriendlyURL += StringPool.SLASH;
+				}
+			}
+			else {
+				String groupFriendlyURLPrefix = groupFriendlyURL.substring(
+					0, pos);
 
-			return sb.toString();
+				String groupFriendlyURLSuffix = groupFriendlyURL.substring(pos);
+
+				StringBundler sb = new StringBundler(3);
+
+				sb.append(groupFriendlyURLPrefix);
+				sb.append(buildI18NPath(siteDefaultLocale));
+				sb.append(groupFriendlyURLSuffix);
+
+				groupFriendlyURL = sb.toString();
+			}
 		}
 
 		return groupFriendlyURL.concat(canonicalLayoutFriendlyURL).concat(

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8307,17 +8307,11 @@ public class PortalImpl implements Portal {
 		String canonicalURLSuffix = canonicalURL.substring(pos);
 
 		if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
-			String defaultLocalePath = _buildI18NPath(
-				siteDefaultLocale.getLanguage(), siteDefaultLocale);
+			String i18nPath = buildI18NPath(siteDefaultLocale);
 
-			int canonicalURLSuffixPos = defaultLocalePath.length() + pos;
-
-			if (canonicalURLSuffixPos >= canonicalURL.length()) {
-				canonicalURLSuffix = StringPool.BLANK;
-			}
-			else {
-				canonicalURLSuffix = canonicalURL.substring(
-					canonicalURLSuffixPos + 1);
+			if (canonicalURLSuffix.startsWith(i18nPath)) {
+				canonicalURLSuffix = canonicalURLSuffix.substring(
+					i18nPath.length());
 			}
 		}
 

--- a/portal-impl/test/integration/com/liferay/portal/util/PortalImplAlternateURLTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/util/PortalImplAlternateURLTest.java
@@ -21,8 +21,10 @@ import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -56,6 +58,7 @@ public class PortalImplAlternateURLTest {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_defaultLocale = LocaleUtil.getDefault();
+		_defaultPrependStyle = PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE;
 
 		LocaleUtil.setDefault(
 			LocaleUtil.US.getLanguage(), LocaleUtil.US.getCountry(),
@@ -233,9 +236,36 @@ public class PortalImplAlternateURLTest {
 		Assert.assertEquals(
 			expectedAssetPublisherContentAlternateURL,
 			actualAssetPublisherContentAlternateURL);
+
+		TestPropsUtil.set(
+			com.liferay.portal.kernel.util.PropsKeys.
+				LOCALE_PREPEND_FRIENDLY_URL_STYLE,
+			"2");
+
+		String actualAlternateURL2 = PortalUtil.getAlternateURL(
+			canonicalURL, getThemeDisplay(_group, canonicalURL),
+			alternateLocale, layout);
+
+		Assert.assertEquals(expectedAlternateURL, actualAlternateURL2);
+
+		String actualAssetPublisherContentAlternateURL2 =
+			PortalUtil.getAlternateURL(
+				canonicalAssetPublisherContentURL,
+				getThemeDisplay(_group, canonicalAssetPublisherContentURL),
+				alternateLocale, layout);
+
+		Assert.assertEquals(
+			expectedAssetPublisherContentAlternateURL,
+			actualAssetPublisherContentAlternateURL2);
+
+		TestPropsUtil.set(
+			com.liferay.portal.kernel.util.PropsKeys.
+				LOCALE_PREPEND_FRIENDLY_URL_STYLE,
+			GetterUtil.getString(_defaultPrependStyle));
 	}
 
 	private static Locale _defaultLocale;
+	private static int _defaultPrependStyle;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/portal-impl/test/integration/com/liferay/portal/util/PortalImplCanonicalURLTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/util/PortalImplCanonicalURLTest.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -64,6 +65,7 @@ public class PortalImplCanonicalURLTest {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_defaultLocale = LocaleUtil.getDefault();
+		_defaultPrependStyle = PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE;
 
 		LocaleUtil.setDefault(
 			LocaleUtil.US.getLanguage(), LocaleUtil.US.getCountry(),
@@ -446,9 +448,6 @@ public class PortalImplCanonicalURLTest {
 		themeDisplay.setServerPort(serverPort);
 		themeDisplay.setSiteGroupId(group.getGroupId());
 
-		String actualCanonicalURL = PortalUtil.getCanonicalURL(
-			completeURL, themeDisplay, layout, forceLayoutFriendlyURL);
-
 		String expectedGroupFriendlyURL = StringPool.BLANK;
 
 		if (!group.isGuest()) {
@@ -467,10 +466,24 @@ public class PortalImplCanonicalURLTest {
 			expectedPortalDomain, port, StringPool.BLANK,
 			expectedGroupFriendlyURL, expectedLayoutFriendlyURL, secure);
 
-		Assert.assertEquals(expectedCanonicalURL, actualCanonicalURL);
+		TestPropsUtil.set(
+			com.liferay.portal.kernel.util.PropsKeys.
+				LOCALE_PREPEND_FRIENDLY_URL_STYLE,
+			"2");
+
+		String actualCanonicalURL2 = PortalUtil.getCanonicalURL(
+			completeURL, themeDisplay, layout, forceLayoutFriendlyURL);
+
+		Assert.assertEquals(expectedCanonicalURL, actualCanonicalURL2);
+
+		TestPropsUtil.set(
+			com.liferay.portal.kernel.util.PropsKeys.
+				LOCALE_PREPEND_FRIENDLY_URL_STYLE,
+			GetterUtil.getString(_defaultPrependStyle));
 	}
 
 	private static Locale _defaultLocale;
+	private static int _defaultPrependStyle;
 
 	private Group _defaultGroup;
 	private Layout _defaultGrouplayout1;


### PR DESCRIPTION
Hi @Preston-Crary,

I have addressed [your previous concerns](https://github.com/Preston-Crary/liferay-portal/pull/466#issuecomment-355630741):
- new cases are tested within the method testCanonicalURL instead of creating new test methods
- unnecessary adaptations to test classes have been suppressed since LPS-74272 does not have LPS-74031's scope

Please, let me know if any additional information is needed for your review.

Best,
Daniel