### PR TITLE
LPS-76994

### DIFF
--- a/modules/apps/web-experience/layout/layout-impl/bnd.bnd
+++ b/modules/apps/web-experience/layout/layout-impl/bnd.bnd
@@ -3,3 +3,4 @@ Bundle-SymbolicName: com.liferay.layout.impl
 Bundle-Version: 2.0.4
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Site Management
+Liferay-Require-SchemaVersion: 1.0.0

--- a/modules/apps/web-experience/layout/layout-impl/build.gradle
+++ b/modules/apps/web-experience/layout/layout-impl/build.gradle
@@ -2,6 +2,7 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
+	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/web-experience/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/LayoutImplUpgrade.java
+++ b/modules/apps/web-experience/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/LayoutImplUpgrade.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.internal.upgrade;
+
+import com.liferay.layout.internal.upgrade.v1_0_0.UpgradeLayoutPermissions;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Michael Bowerman
+ */
+@Component(
+	immediate = true,
+	service = {LayoutImplUpgrade.class, UpgradeStepRegistrator.class}
+)
+public class LayoutImplUpgrade implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+		registry.register(
+			"com.liferay.layout.impl", "0.0.0", "1.0.0",
+			new UpgradeLayoutPermissions());
+	}
+
+}

--- a/modules/apps/web-experience/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_0/UpgradeLayoutPermissions.java
+++ b/modules/apps/web-experience/layout/layout-impl/src/main/java/com/liferay/layout/internal/upgrade/v1_0_0/UpgradeLayoutPermissions.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.internal.upgrade.v1_0_0;
+
+import com.liferay.portal.dao.orm.common.SQLTransformer;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.StringBundler;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Michael Bowerman
+ */
+public class UpgradeLayoutPermissions extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		StringBundler sb = new StringBundler(9);
+
+		sb.append("select Layout.companyId, Layout.plid, ");
+		sb.append("Layout.privateLayout, Layout.groupId from Layout left ");
+		sb.append("join ResourcePermission on (ResourcePermission.companyId ");
+		sb.append("= Layout.companyId and ResourcePermission.name = '");
+		sb.append(Layout.class.getName());
+		sb.append("' and ResourcePermission.scope = ");
+		sb.append(ResourceConstants.SCOPE_INDIVIDUAL);
+		sb.append(" and ResourcePermission.primKey = CAST_TEXT(Layout.plid)) ");
+		sb.append("where ResourcePermission.resourcePermissionId is null");
+
+		String sql = SQLTransformer.transform(sb.toString());
+
+		try (LoggingTimer loggingTimer = new LoggingTimer();
+			PreparedStatement ps = connection.prepareStatement(sql);
+			ResultSet rs = ps.executeQuery()) {
+
+			while (rs.next()) {
+				long companyId = rs.getLong("companyId");
+				long plid = rs.getLong("plid");
+				boolean privateLayout = rs.getBoolean("privateLayout");
+				long groupId = rs.getLong("groupId");
+
+				boolean addGroupPermission = true;
+				boolean addGuestPermission = true;
+
+				if (privateLayout) {
+					addGuestPermission = false;
+
+					Group group = GroupLocalServiceUtil.getGroup(groupId);
+
+					if (group.isUser() || group.isUserGroup()) {
+						addGroupPermission = false;
+					}
+				}
+
+				ResourceLocalServiceUtil.addResources(
+					companyId, groupId, 0, Layout.class.getName(), plid, false,
+					addGroupPermission, addGuestPermission);
+			}
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/service/permission/LayoutPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/LayoutPermissionImpl.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
-import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
@@ -257,30 +256,6 @@ public class LayoutPermissionImpl
 
 				parentLayoutId = parentLayout.getParentLayoutId();
 			}
-		}
-
-		int resourcePermissionsCount =
-			ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
-				layout.getCompanyId(), Layout.class.getName(),
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(layout.getPlid()));
-
-		if (resourcePermissionsCount == 0) {
-			boolean addGroupPermission = true;
-			boolean addGuestPermission = true;
-
-			if (layout.isPrivateLayout()) {
-				addGuestPermission = false;
-
-				if (group.isUser() || group.isUserGroup()) {
-					addGroupPermission = false;
-				}
-			}
-
-			ResourceLocalServiceUtil.addResources(
-				layout.getCompanyId(), layout.getGroupId(), 0,
-				Layout.class.getName(), layout.getPlid(), false,
-				addGroupPermission, addGuestPermission);
 		}
 
 		if (permissionChecker.hasPermission(


### PR DESCRIPTION
Hi @Preston-Crary,

Unfortunately, I don't know why the lazy evaluation for layout resource permissions was added, since it was added so long ago and our only form of documentation is a vague commit message. The eager evaluation seems to have been added in https://github.com/liferay/liferay-portal/commit/7dd4d185a50003de88eb5d57ec4e3fe00e1bcb7b, which is also in 2006 and does not have any explanation as to why it was added. My guess is that the lazy evaluation was added as a failsafe in case if someone was using the portal before the eager evaluation was added. 

When I looked through the portal for any usages of `layoutPersistence#update` and `LayoutUtil#update`, the only results (aside from the previously discussed BaseImpl methods, which are not called by any Liferay code) were usages that could not be adding a new Layout to the database, aside from `LayoutLocalServiceImpl#addLayout`, which was also adding the resources. I also was unable to find any instances of Layouts being added via direct SQL. Since these are the only ways in which a Layout can be added to the database, it shouldn't be possible (aside from customizations) to add a Layout to the database without also adding the resource permissions for it.