### PR TITLE
LPS-77681

### DIFF
--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1517,6 +1517,14 @@ public class LanguageImpl implements Language, Serializable {
 	}
 
 	@Override
+	public boolean isSameLanguage(Locale locale1, Locale locale2) {
+		String language1 = locale1.getLanguage();
+		String language2 = locale2.getLanguage();
+
+		return language1.equals(language2);
+	}
+
+	@Override
 	public String process(
 		ResourceBundle resourceBundle, Locale locale, String content) {
 

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1618,8 +1618,13 @@ public class LanguageImpl implements Language, Serializable {
 			UnicodeProperties typeSettingsProperties =
 				group.getTypeSettingsProperties();
 
-			languageIds = StringUtil.split(
-				typeSettingsProperties.getProperty(PropsKeys.LOCALES));
+			String groupLanguageIds = typeSettingsProperties.getProperty(
+				PropsKeys.LOCALES);
+
+			if (groupLanguageIds != null) {
+				languageIds = StringUtil.split(
+					typeSettingsProperties.getProperty(PropsKeys.LOCALES));
+			}
 		}
 		catch (Exception e) {
 		}

--- a/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
@@ -224,9 +224,23 @@ public class I18nServlet extends HttpServlet {
 	protected I18nData getI18nData(Locale locale) {
 		String languageId = LocaleUtil.toLanguageId(locale);
 
+		String i18nPath = StringPool.SLASH + languageId;
+
+		Locale defaultLocale = LocaleUtil.getDefault();
+
+		if (LocaleUtil.equals(defaultLocale, locale)) {
+			i18nPath = StringPool.SLASH + defaultLocale.getLanguage();
+		}
+		else if (!LanguageUtil.isSameLanguage(defaultLocale, locale)) {
+			defaultLocale = LanguageUtil.getLocale(locale.getLanguage());
+
+			if (LocaleUtil.equals(defaultLocale, locale)) {
+				i18nPath = StringPool.SLASH + defaultLocale.getLanguage();
+			}
+		}
+
 		return new I18nData(
-			StringPool.SLASH + languageId, locale.getLanguage(), languageId,
-			StringPool.SLASH);
+			i18nPath, locale.getLanguage(), languageId, StringPool.SLASH);
 	}
 
 	protected class I18nData {

--- a/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
@@ -175,9 +175,19 @@ public class I18nServlet extends HttpServlet {
 				(Long)request.getAttribute(WebKeys.COMPANY_ID), friendlyURL);
 
 			siteDefaultLocale = PortalUtil.getSiteDefaultLocale(siteGroup);
+
+			if (!LanguageUtil.isSameLanguage(locale, siteDefaultLocale)) {
+				siteDefaultLocale = LanguageUtil.getLocale(
+					siteGroup.getGroupId(), locale.getLanguage());
+			}
 		}
 		catch (Exception e) {
 			siteDefaultLocale = LocaleUtil.getDefault();
+
+			if (!LanguageUtil.isSameLanguage(locale, siteDefaultLocale)) {
+				siteDefaultLocale = LanguageUtil.getLocale(
+					locale.getLanguage());
+			}
 		}
 
 		String siteDefaultLanguageId = LanguageUtil.getLanguageId(

--- a/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
@@ -20,6 +20,8 @@ import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -160,11 +162,30 @@ public class I18nServlet extends HttpServlet {
 
 		String i18nLanguageCode = i18nLanguageId;
 
-		if ((locale == null) || Validator.isNull(locale.getCountry())) {
+		Locale siteDefaultLocale = null;
 
-			// Locales must contain the country code
+		try {
+			int[] friendlyURLIndices = PortalUtil.getGroupFriendlyURLIndex(
+				path);
 
-			locale = LanguageUtil.getLocale(i18nLanguageCode);
+			String friendlyURL = path.substring(
+				friendlyURLIndices[0], friendlyURLIndices[1]);
+
+			Group siteGroup = GroupLocalServiceUtil.getFriendlyURLGroup(
+				(Long)request.getAttribute(WebKeys.COMPANY_ID), friendlyURL);
+
+			siteDefaultLocale = PortalUtil.getSiteDefaultLocale(siteGroup);
+		}
+		catch (Exception e) {
+		}
+
+		String siteDefaultLanguageId = LanguageUtil.getLanguageId(
+			siteDefaultLocale);
+
+		if (siteDefaultLanguageId.startsWith(i18nLanguageId)) {
+			locale = siteDefaultLocale;
+
+			i18nPath = StringPool.SLASH + locale.getLanguage();
 		}
 
 		if (locale != null) {

--- a/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
@@ -177,6 +177,7 @@ public class I18nServlet extends HttpServlet {
 			siteDefaultLocale = PortalUtil.getSiteDefaultLocale(siteGroup);
 		}
 		catch (Exception e) {
+			siteDefaultLocale = LocaleUtil.getDefault();
 		}
 
 		String siteDefaultLanguageId = LanguageUtil.getLanguageId(

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -5095,12 +5095,10 @@ public class PortalImpl implements Portal {
 	}
 
 	@Override
-	public Locale getSiteDefaultLocale(long groupId) throws PortalException {
-		if (groupId <= 0) {
+	public Locale getSiteDefaultLocale(Group group) throws PortalException {
+		if (group == null) {
 			return LocaleUtil.getDefault();
 		}
-
-		Group group = GroupLocalServiceUtil.getGroup(groupId);
 
 		Group liveGroup = group;
 
@@ -5126,6 +5124,17 @@ public class PortalImpl implements Portal {
 			defaultUser.getLanguageId());
 
 		return LocaleUtil.fromLanguageId(languageId);
+	}
+
+	@Override
+	public Locale getSiteDefaultLocale(long groupId) throws PortalException {
+		if (groupId <= 0) {
+			return LocaleUtil.getDefault();
+		}
+
+		Group group = GroupLocalServiceUtil.fetchGroup(groupId);
+
+		return getSiteDefaultLocale(group);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -7460,6 +7460,10 @@ public class PortalImpl implements Portal {
 			companyId, groupId, 0, name, primaryKey, false, true, true);
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	protected String buildI18NPath(Locale locale) {
 		String languageId = LocaleUtil.toLanguageId(locale);
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8265,6 +8265,13 @@ public class PortalImpl implements Portal {
 			siteDefaultLocale = getSiteDefaultLocale(group);
 		}
 		catch (Exception e) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to get default locale from group: " +
+						group.getGroupId() + ".  Using portal defaults.");
+			}
+
+			siteDefaultLocale = LocaleUtil.getDefault();
 		}
 
 		String siteDefaultLanguageId = LanguageUtil.getLanguageId(

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8252,6 +8252,31 @@ public class PortalImpl implements Portal {
 		return StringPool.SLASH.concat(languageId);
 	}
 
+	private String _buildI18NPath(
+		String languageId, Locale locale, Group group) {
+
+		if (Validator.isNull(languageId)) {
+			return null;
+		}
+
+		Locale siteDefaultLocale = null;
+
+		try {
+			siteDefaultLocale = getSiteDefaultLocale(group);
+		}
+		catch (Exception e) {
+		}
+
+		String siteDefaultLanguageId = LanguageUtil.getLanguageId(
+			siteDefaultLocale);
+
+		if (siteDefaultLanguageId.startsWith(languageId)) {
+			languageId = siteDefaultLocale.getLanguage();
+		}
+
+		return StringPool.SLASH.concat(languageId);
+	}
+
 	private Map<Locale, String> _getAlternateURLs(
 			String canonicalURL, ThemeDisplay themeDisplay, Layout layout,
 			Set<Locale> availableLocales)

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8263,6 +8263,11 @@ public class PortalImpl implements Portal {
 
 		try {
 			siteDefaultLocale = getSiteDefaultLocale(group);
+
+			if (!LanguageUtil.isSameLanguage(locale, siteDefaultLocale)) {
+				siteDefaultLocale = LanguageUtil.getLocale(
+					group.getGroupId(), locale.getLanguage());
+			}
 		}
 		catch (Exception e) {
 			if (_log.isWarnEnabled()) {
@@ -8272,6 +8277,11 @@ public class PortalImpl implements Portal {
 			}
 
 			siteDefaultLocale = LocaleUtil.getDefault();
+
+			if (!LanguageUtil.isSameLanguage(locale, siteDefaultLocale)) {
+				siteDefaultLocale = LanguageUtil.getLocale(
+					locale.getLanguage());
+			}
 		}
 
 		String siteDefaultLanguageId = LanguageUtil.getLanguageId(

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1403,7 +1403,7 @@ public class PortalImpl implements Portal {
 
 			if ((pos <= 0) || (pos >= groupFriendlyURL.length())) {
 				sb.append(groupFriendlyURL);
-				sb.append(buildI18NPath(siteDefaultLocale));
+				sb.append(_buildI18NPath(siteDefaultLocale, layout.getGroup()));
 
 				if (!canonicalLayoutFriendlyURL.startsWith(StringPool.SLASH)) {
 					sb.append(StringPool.SLASH);
@@ -1416,7 +1416,7 @@ public class PortalImpl implements Portal {
 				String groupFriendlyURLSuffix = groupFriendlyURL.substring(pos);
 
 				sb.append(groupFriendlyURLPrefix);
-				sb.append(buildI18NPath(siteDefaultLocale));
+				sb.append(_buildI18NPath(siteDefaultLocale, layout.getGroup()));
 				sb.append(groupFriendlyURLSuffix);
 			}
 
@@ -8224,12 +8224,18 @@ public class PortalImpl implements Portal {
 			 !locale.equals(LocaleUtil.getDefault())) ||
 			(PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2)) {
 
-			i18nPath = buildI18NPath(locale);
+			i18nPath = _buildI18NPath(locale, themeDisplay.getSiteGroup());
 		}
 
 		themeDisplay.setI18nLanguageId(locale.toString());
 		themeDisplay.setI18nPath(i18nPath);
 		themeDisplay.setLocale(locale);
+	}
+
+	private String _buildI18NPath(Locale locale, Group group) {
+		String languageId = LocaleUtil.toLanguageId(locale);
+
+		return _buildI18NPath(languageId, locale, group);
 	}
 
 	private String _buildI18NPath(String languageId, Locale locale) {
@@ -8321,7 +8327,8 @@ public class PortalImpl implements Portal {
 
 		if (Validator.isNull(virtualHostname)) {
 			for (Locale locale : availableLocales) {
-				String i18nPath = buildI18NPath(locale);
+				String i18nPath = _buildI18NPath(
+					locale, themeDisplay.getSiteGroup());
 
 				alternateURLs.put(
 					locale,
@@ -8350,7 +8357,9 @@ public class PortalImpl implements Portal {
 		if ((pos <= 0) || (pos >= canonicalURL.length())) {
 			for (Locale locale : availableLocales) {
 				alternateURLs.put(
-					locale, canonicalURL.concat(buildI18NPath(locale)));
+					locale,
+					canonicalURL.concat(
+						_buildI18NPath(locale, themeDisplay.getSiteGroup())));
 			}
 
 			return alternateURLs;
@@ -8400,7 +8409,8 @@ public class PortalImpl implements Portal {
 		String canonicalURLSuffix = canonicalURL.substring(pos);
 
 		if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
-			String i18nPath = buildI18NPath(siteDefaultLocale);
+			String i18nPath = _buildI18NPath(
+				siteDefaultLocale, layout.getGroup());
 
 			if (canonicalURLSuffix.startsWith(i18nPath)) {
 				canonicalURLSuffix = canonicalURLSuffix.substring(
@@ -8449,8 +8459,10 @@ public class PortalImpl implements Portal {
 				alternateURLs.put(
 					locale,
 					canonicalURLPrefix.concat(
-						_buildI18NPath(languageId, locale)).concat(
-							alternateURLSuffix));
+						_buildI18NPath(
+							languageId, locale,
+							themeDisplay.getSiteGroup())).concat(
+								alternateURLSuffix));
 			}
 		}
 

--- a/portal-impl/test/integration/com/liferay/portal/servlet/I18nServletTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/servlet/I18nServletTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
 
@@ -176,6 +177,57 @@ public class I18nServletTest {
 			mockHttpServletRequest);
 
 		Assert.assertEquals(expectedI18nData, actualI18nData);
+	}
+
+	protected void testI18nData(
+		Group group, Locale locale, Locale expectedDefaultLocale) {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_createMockHttpServletRequest(group, locale.getLanguage());
+
+		I18nServlet.I18nData languageOnlyPath = _i18nServlet.getI18nData(
+			mockHttpServletRequest);
+
+		mockHttpServletRequest = _createMockHttpServletRequest(
+			group, LocaleUtil.toLanguageId(locale));
+
+		I18nServlet.I18nData languageAndLocalePath = _i18nServlet.getI18nData(
+			mockHttpServletRequest);
+
+		Assert.assertEquals(
+			languageAndLocalePath.getLanguageId(),
+			LocaleUtil.toLanguageId(locale));
+
+		if (expectedDefaultLocale.equals(locale)) {
+			Assert.assertEquals(languageOnlyPath, languageAndLocalePath);
+		}
+		else {
+			Assert.assertEquals(
+				languageOnlyPath.getLanguageId(),
+				LocaleUtil.toLanguageId(expectedDefaultLocale));
+
+			Assert.assertNotEquals(languageOnlyPath, languageAndLocalePath);
+		}
+	}
+
+	private MockHttpServletRequest _createMockHttpServletRequest(
+		Group group, String path) {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		if (group != null) {
+			mockHttpServletRequest.setAttribute(
+				WebKeys.COMPANY_ID, group.getCompanyId());
+
+			mockHttpServletRequest.setPathInfo(
+				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
+					group.getFriendlyURL());
+		}
+
+		mockHttpServletRequest.setServletPath(StringPool.SLASH + path);
+
+		return mockHttpServletRequest;
 	}
 
 	private static Set<Locale> _availableLocales;

--- a/portal-impl/test/integration/com/liferay/portal/servlet/I18nServletTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/servlet/I18nServletTest.java
@@ -114,6 +114,35 @@ public class I18nServletTest {
 	}
 
 	@Test
+	public void testDefaultCompanyI18nData() throws Exception {
+		//Default Locale
+		testI18nData(null, LocaleUtil.US, LocaleUtil.US);
+
+		//First-found Locales
+		testI18nData(null, LocaleUtil.CANADA_FRENCH, LocaleUtil.CANADA_FRENCH);
+		testI18nData(null, LocaleUtil.SPAIN, LocaleUtil.SPAIN);
+
+		//Duplicate Language
+		testI18nData(null, LocaleUtil.UK, LocaleUtil.US);
+	}
+
+	@Test
+	public void testDefaultGroupI18nData() throws Exception {
+		LanguageUtil.resetAvailableGroupLocales(_group.getGroupId());
+
+		//Default Locale
+		testI18nData(_group, LocaleUtil.US, LocaleUtil.US);
+
+		//First-found Locales
+		testI18nData(
+			_group, LocaleUtil.CANADA_FRENCH, LocaleUtil.CANADA_FRENCH);
+		testI18nData(_group, LocaleUtil.SPAIN, LocaleUtil.SPAIN);
+
+		//Duplicate Language
+		testI18nData(_group, LocaleUtil.UK, LocaleUtil.US);
+	}
+
+	@Test
 	public void testI18nNotUseDefaultExistentLocale() throws Exception {
 		PropsValues.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE = false;
 
@@ -156,6 +185,27 @@ public class I18nServletTest {
 		Locale expectedLocale = LocaleUtil.CHINA;
 
 		testGetI18nData(expectedLocale, getI18nData(expectedLocale));
+	}
+
+	@Test
+	public void testModifiedGroupI18nData() throws Exception {
+		GroupTestUtil.resetGroupLocales(
+			_group.getGroupId(),
+			Arrays.asList(
+				LocaleUtil.CANADA_FRENCH, LocaleUtil.SPAIN, LocaleUtil.UK,
+				LocaleUtil.US),
+			LocaleUtil.SPAIN);
+
+		//Default Locale
+		testI18nData(_group, LocaleUtil.SPAIN, LocaleUtil.SPAIN);
+
+		//First-found Locales
+		testI18nData(
+			_group, LocaleUtil.CANADA_FRENCH, LocaleUtil.CANADA_FRENCH);
+		testI18nData(_group, LocaleUtil.UK, LocaleUtil.UK);
+
+		//Duplicate Language
+		testI18nData(_group, LocaleUtil.US, LocaleUtil.UK);
 	}
 
 	protected I18nServlet.I18nData getI18nData(Locale locale) {

--- a/portal-impl/test/integration/com/liferay/portal/servlet/I18nServletTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/servlet/I18nServletTest.java
@@ -16,10 +16,16 @@ package com.liferay.portal.servlet;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
 
@@ -83,9 +89,21 @@ public class I18nServletTest {
 	}
 
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		_originalLocaleUseDefaultIfNotAvailable =
 			PropsValues.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE;
+
+		_group = GroupTestUtil.addGroup();
+
+		UnicodeProperties typeSettingsProperties =
+			_group.getTypeSettingsProperties();
+
+		typeSettingsProperties.put(
+			GroupConstants.TYPE_SETTINGS_KEY_INHERIT_LOCALES, "false");
+
+		_group.setTypeSettingsProperties(typeSettingsProperties);
+
+		GroupLocalServiceUtil.updateGroup(_group);
 	}
 
 	@After
@@ -162,6 +180,9 @@ public class I18nServletTest {
 
 	private static Set<Locale> _availableLocales;
 	private static Locale _defaultLocale;
+
+	@DeleteAfterTestRun
+	private static Group _group;
 
 	private static String[] _localesEnabled;
 

--- a/portal-impl/test/integration/com/liferay/portal/servlet/I18nServletTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/servlet/I18nServletTest.java
@@ -52,6 +52,7 @@ public class I18nServletTest {
 	public static void setUpClass() throws Exception {
 		_availableLocales = LanguageUtil.getAvailableLocales();
 		_defaultLocale = LocaleUtil.getDefault();
+		_localesEnabled = PropsValues.LOCALES_ENABLED;
 
 		LanguageUtil.init();
 
@@ -61,6 +62,13 @@ public class I18nServletTest {
 				LocaleUtil.CANADA_FRENCH, LocaleUtil.SPAIN, LocaleUtil.UK,
 				LocaleUtil.US),
 			LocaleUtil.US);
+
+		PropsValues.LOCALES_ENABLED = new String[] {
+			LanguageUtil.getLanguageId(LocaleUtil.CANADA_FRENCH),
+			LanguageUtil.getLanguageId(LocaleUtil.SPAIN),
+			LanguageUtil.getLanguageId(LocaleUtil.UK),
+			LanguageUtil.getLanguageId(LocaleUtil.US)
+		};
 	}
 
 	@AfterClass
@@ -70,6 +78,8 @@ public class I18nServletTest {
 		CompanyTestUtil.resetCompanyLocales(
 			PortalUtil.getDefaultCompanyId(), _availableLocales,
 			_defaultLocale);
+
+		PropsValues.LOCALES_ENABLED = _localesEnabled;
 	}
 
 	@Before
@@ -152,6 +162,8 @@ public class I18nServletTest {
 
 	private static Set<Locale> _availableLocales;
 	private static Locale _defaultLocale;
+
+	private static String[] _localesEnabled;
 
 	private final I18nServlet _i18nServlet = new I18nServlet();
 	private boolean _originalLocaleUseDefaultIfNotAvailable;

--- a/portal-impl/test/integration/com/liferay/portal/servlet/I18nServletTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/servlet/I18nServletTest.java
@@ -53,15 +53,20 @@ public class I18nServletTest {
 		_availableLocales = LanguageUtil.getAvailableLocales();
 		_defaultLocale = LocaleUtil.getDefault();
 
+		LanguageUtil.init();
+
 		CompanyTestUtil.resetCompanyLocales(
 			PortalUtil.getDefaultCompanyId(),
 			Arrays.asList(
-				LocaleUtil.CANADA_FRENCH, LocaleUtil.SPAIN, LocaleUtil.US),
+				LocaleUtil.CANADA_FRENCH, LocaleUtil.SPAIN, LocaleUtil.UK,
+				LocaleUtil.US),
 			LocaleUtil.US);
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
+		LanguageUtil.init();
+
 		CompanyTestUtil.resetCompanyLocales(
 			PortalUtil.getDefaultCompanyId(), _availableLocales,
 			_defaultLocale);

--- a/portal-kernel/src/com/liferay/portal/kernel/language/Language.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/language/Language.java
@@ -171,6 +171,8 @@ public interface Language {
 
 	public boolean isInheritLocales(long groupId) throws PortalException;
 
+	public boolean isSameLanguage(Locale locale1, Locale locale2);
+
 	public String process(
 		ResourceBundle resourceBundle, Locale locale, String content);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/language/LanguageUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/language/LanguageUtil.java
@@ -324,6 +324,10 @@ public class LanguageUtil {
 		return getLanguage().isInheritLocales(groupId);
 	}
 
+	public static boolean isSameLanguage(Locale locale1, Locale locale2) {
+		return getLanguage().isSameLanguage(locale1, locale2);
+	}
+
 	public static boolean isValidLanguageKey(Locale locale, String key) {
 		String value = getLanguage().get(locale, key, StringPool.BLANK);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -1122,6 +1122,8 @@ public interface Portal {
 	public long[] getSiteAndCompanyGroupIds(ThemeDisplay themeDisplay)
 		throws PortalException;
 
+	public Locale getSiteDefaultLocale(Group group) throws PortalException;
+
 	public Locale getSiteDefaultLocale(long groupId) throws PortalException;
 
 	public long getSiteGroupId(long groupId);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -1805,6 +1805,12 @@ public class PortalUtil {
 		return getPortal().getSiteAndCompanyGroupIds(themeDisplay);
 	}
 
+	public static Locale getSiteDefaultLocale(Group group)
+		throws PortalException {
+
+		return getPortal().getSiteDefaultLocale(group);
+	}
+
 	public static Locale getSiteDefaultLocale(long groupId)
 		throws PortalException {
 

--- a/portal-test/src/com/liferay/portal/kernel/test/util/GroupTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/GroupTestUtil.java
@@ -20,6 +20,7 @@ import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cache.thread.local.Lifecycle;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCacheManager;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
@@ -29,6 +30,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -190,6 +192,44 @@ public class GroupTestUtil {
 
 		StagingLocalServiceUtil.enableLocalStaging(
 			userId, group, false, false, serviceContext);
+	}
+
+	public static void resetGroupLocales(
+			long groupId, Collection<Locale> locales, Locale defaultLocale)
+		throws Exception {
+
+		String defaultLanguageId = LocaleUtil.toLanguageId(defaultLocale);
+
+		String languageIds = StringUtil.merge(
+			LocaleUtil.toLanguageIds(locales));
+
+		resetGroupLocales(groupId, languageIds, defaultLanguageId);
+	}
+
+	public static void resetGroupLocales(
+			long groupId, String languageIds, String defaultLanguageId)
+		throws Exception {
+
+		// Reset group default locale
+
+		Group group = GroupLocalServiceUtil.getGroup(groupId);
+
+		UnicodeProperties typeSettingsProperties =
+			group.getTypeSettingsProperties();
+
+		typeSettingsProperties.put(PropsKeys.LOCALES, languageIds);
+		typeSettingsProperties.put("languageId", defaultLanguageId);
+
+		GroupLocalServiceUtil.updateGroup(group);
+
+		// Reset group locales cache
+
+		LanguageUtil.resetAvailableGroupLocales(groupId);
+
+		// Reset thread locals
+
+		GroupThreadLocal.setGroupId(groupId);
+		System.out.println("reset GroupThreadLocal!");
 	}
 
 	public static Group updateDisplaySettings(


### PR DESCRIPTION
See https://github.com/shuyangzhou/liferay-portal/pull/5665

I've made changes based off your requests.  See the below items for explanations:

> 1. Create a test in either PortalImplLayoutFriendlyURLTest or LayoutFriendlyURLTest.

I've created tests in I18nServletTest.java, and have found [PortalImplLocaleTest.java](https://github.com/liferay/liferay-portal/blob/master/portal-impl/test/integration/com/liferay/portal/util/PortalImplLocaleTest.java) seems to cover my changes as well.
> 2. Deprecate the old unused protected method.

[Done here](https://github.com/Preston-Crary/liferay-portal/commit/b254bfd47c6dfdc8778e6c31e304d58f695cb77a)
> 3. Pass down the group instead of the groupId to avoid all the extra group refetches.

[Done here](https://github.com/Preston-Crary/liferay-portal/commit/2ec0003ac3af06cd1d2a61971ecfbe6899415411)
> 4. Compare the locales where appropriate to reduce the number of variables in the methods.

I've reduced the checking to only three times.  First if the Locale is the default, next if it's the same language, and finally if it's the first-available.
> 5. Remove the empty catch block by adding an condition on if the group is null.

If there is an issue retrieving the group, the catch blocks are now used to gather the _portal_ default locale.

Please let me know if you have any questions; I'm in the office this week.  Thanks!