### PR TITLE
LPS-74690

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -473,6 +473,8 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 			ps1.setString(3, fileName);
 
 			try (ResultSet rs = ps1.executeQuery()) {
+				rs.next();
+
 				while (rs.next()) {
 					long fileEntryId = rs.getLong("fileEntryId");
 					String extension = GetterUtil.getString(

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -496,10 +496,10 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 					}
 
 					do {
-						String iString = String.valueOf(i);
+						String count = String.valueOf(i);
 
 						int availableLength =
-							254 - (extension.length() + iString.length());
+							254 - (extension.length() + count.length());
 
 						if (Validator.isNotNull(extension)) {
 							availableLength--;
@@ -513,7 +513,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 
 						title =
 							titleWithoutExtension + StringPool.UNDERLINE +
-								iString;
+								count;
 
 						if (Validator.isNotNull(titleExtension)) {
 							title = title.concat(titleExtension);

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -494,9 +494,20 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 					}
 
 					for (int i = 1;; i++) {
+						String iString = String.valueOf(i);
+
+						int availableLength =
+							254 - (titleExtension.length() + iString.length());
+
+						if (titleWithoutExtension.length() > availableLength) {
+							titleWithoutExtension =
+								titleWithoutExtension.substring(
+									0, availableLength);
+						}
+
 						title =
 							titleWithoutExtension + StringPool.UNDERLINE +
-								String.valueOf(i);
+								iString;
 
 						if (Validator.isNotNull(titleExtension)) {
 							title = title.concat(titleExtension);

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -499,7 +499,11 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 						String iString = String.valueOf(i);
 
 						int availableLength =
-							254 - (titleExtension.length() + iString.length());
+							254 - (extension.length() + iString.length());
+
+						if (Validator.isNotNull(extension)) {
+							availableLength--;
+						}
 
 						if (titleWithoutExtension.length() > availableLength) {
 							titleWithoutExtension =

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -482,8 +482,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 					String title = GetterUtil.getString(rs.getString("title"));
 					String version = rs.getString("version");
 
-					String uniqueFileName = DLUtil.getSanitizedFileName(
-						title, extension);
+					String uniqueFileName = null;
 
 					String titleExtension = StringPool.BLANK;
 					String titleWithoutExtension = title;
@@ -493,61 +492,44 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 						titleWithoutExtension = FileUtil.stripExtension(title);
 					}
 
-					boolean generatedUniqueFileName = false;
-					String uniqueTitle = title;
-
 					for (int i = 1;; i++) {
-						if (!generatedUniqueFileNames.contains(
-								uniqueFileName) &&
-							!generatedUniqueTitles.contains(uniqueTitle) &&
-							!hasFileEntry(
-								groupId, folderId, fileEntryId, uniqueTitle,
-								uniqueFileName)) {
-
-							break;
-						}
-
-						generatedUniqueFileName = true;
-
-						uniqueTitle =
+						title =
 							titleWithoutExtension + StringPool.UNDERLINE +
 								String.valueOf(i);
 
 						if (Validator.isNotNull(titleExtension)) {
-							uniqueTitle += StringPool.PERIOD.concat(
-								titleExtension);
+							title += StringPool.PERIOD.concat(titleExtension);
 						}
 
 						uniqueFileName = DLUtil.getSanitizedFileName(
-							uniqueTitle, extension);
+							title, extension);
+
+						if (!generatedUniqueFileNames.contains(
+								uniqueFileName) &&
+							!generatedUniqueTitles.contains(title) &&
+							!hasFileEntry(
+								groupId, folderId, fileEntryId, title,
+								uniqueFileName)) {
+
+							break;
+						}
 					}
 
-					if (generatedUniqueFileName) {
-						generatedUniqueFileNames.add(uniqueFileName);
-						generatedUniqueTitles.add(uniqueTitle);
-					}
+					generatedUniqueFileNames.add(uniqueFileName);
+					generatedUniqueTitles.add(title);
 
 					ps2.setString(1, uniqueFileName);
-
-					if (Validator.isNotNull(uniqueTitle)) {
-						ps2.setString(2, uniqueTitle);
-					}
-					else {
-						ps2.setString(2, title);
-					}
-
+					ps2.setString(2, title);
 					ps2.setLong(3, fileEntryId);
 
 					ps2.addBatch();
 
-					if (Validator.isNotNull(uniqueTitle)) {
-						ps3.setString(1, uniqueTitle);
-						ps3.setLong(2, fileEntryId);
-						ps3.setString(3, version);
-						ps3.setInt(4, WorkflowConstants.STATUS_IN_TRASH);
+					ps3.setString(1, title);
+					ps3.setLong(2, fileEntryId);
+					ps3.setString(3, version);
+					ps3.setInt(4, WorkflowConstants.STATUS_IN_TRASH);
 
-						ps3.addBatch();
-					}
+					ps3.addBatch();
 				}
 
 				ps2.executeBatch();

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -488,8 +487,10 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 					String titleWithoutExtension = title;
 
 					if (title.endsWith(StringPool.PERIOD + extension)) {
-						titleExtension = extension;
-						titleWithoutExtension = FileUtil.stripExtension(title);
+						titleExtension = StringPool.PERIOD + extension;
+
+						titleWithoutExtension = titleWithoutExtension.substring(
+							0, title.length() - titleExtension.length());
 					}
 
 					for (int i = 1;; i++) {
@@ -498,7 +499,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 								String.valueOf(i);
 
 						if (Validator.isNotNull(titleExtension)) {
-							title += StringPool.PERIOD.concat(titleExtension);
+							title = title.concat(titleExtension);
 						}
 
 						uniqueFileName = DLUtil.getSanitizedFileName(

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -474,6 +474,8 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 			try (ResultSet rs = ps1.executeQuery()) {
 				rs.next();
 
+				int i = 1;
+
 				while (rs.next()) {
 					long fileEntryId = rs.getLong("fileEntryId");
 					String extension = GetterUtil.getString(
@@ -493,7 +495,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 							0, title.length() - titleExtension.length());
 					}
 
-					for (int i = 1;; i++) {
+					do {
 						String iString = String.valueOf(i);
 
 						int availableLength =
@@ -516,16 +518,13 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 						uniqueFileName = DLUtil.getSanitizedFileName(
 							title, extension);
 
-						if (!generatedUniqueFileNames.contains(
-								uniqueFileName) &&
-							!generatedUniqueTitles.contains(title) &&
-							!hasFileEntry(
-								groupId, folderId, fileEntryId, title,
-								uniqueFileName)) {
-
-							break;
-						}
+						i++;
 					}
+					while (generatedUniqueFileNames.contains(uniqueFileName) ||
+						   generatedUniqueTitles.contains(title) ||
+						   hasFileEntry(
+							   groupId, folderId, fileEntryId, title,
+							   uniqueFileName));
 
 					generatedUniqueFileNames.add(uniqueFileName);
 					generatedUniqueTitles.add(title);


### PR DESCRIPTION
The fix seeks to take advantage of the fact that most of the things done by DLUtil.sanitizeFileName can be automated and done in bulk by SQL. DLUtil.sanitizeFileName does the following three things:

1. Replaces forward slashes with underscores.
2. Appends the extension to the file name if the extension exists and the file name does not already have it.
3. Truncates the portion of the file name before the extension if necessary so that the file name is no greater than 255 characters.

Let me know if you have any questions about the fix.