### PR TITLE
LPS-80401 Tests

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/permission/MBPortletPermissionLogic.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/permission/MBPortletPermissionLogic.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.message.boards.internal.permission;
+
+import com.liferay.message.boards.service.MBBanLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermissionLogic;
+
+/**
+ * @author Sergio González
+ */
+public class MBPortletPermissionLogic
+	implements PortletResourcePermissionLogic {
+
+	public MBPortletPermissionLogic(MBBanLocalService mbBanLocalService) {
+		_mbBanLocalService = mbBanLocalService;
+	}
+
+	@Override
+	public Boolean contains(
+		PermissionChecker permissionChecker, String name, Group group,
+		String actionId) {
+
+		if (_mbBanLocalService.hasBan(
+				group.getGroupId(), permissionChecker.getUserId())) {
+
+			return false;
+		}
+
+		return null;
+	}
+
+	private final MBBanLocalService _mbBanLocalService;
+
+}

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/permission/MBPortletPermissionRegistrar.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/permission/MBPortletPermissionRegistrar.java
@@ -17,6 +17,7 @@ package com.liferay.message.boards.internal.permission;
 import com.liferay.exportimport.kernel.staging.permission.StagingPermission;
 import com.liferay.message.boards.constants.MBConstants;
 import com.liferay.message.boards.constants.MBPortletKeys;
+import com.liferay.message.boards.service.MBBanLocalService;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermissionFactory;
 import com.liferay.portal.kernel.security.permission.resource.StagedPortletPermissionLogic;
@@ -47,6 +48,7 @@ public class MBPortletPermissionRegistrar {
 			PortletResourcePermission.class,
 			PortletResourcePermissionFactory.create(
 				MBConstants.RESOURCE_NAME,
+				new MBPortletPermissionLogic(_mbBanLocalService),
 				new StagedPortletPermissionLogic(
 					_stagingPermission, MBPortletKeys.MESSAGE_BOARDS)),
 			properties);
@@ -56,6 +58,9 @@ public class MBPortletPermissionRegistrar {
 	public void deactivate() {
 		_serviceRegistration.unregister();
 	}
+
+	@Reference
+	private MBBanLocalService _mbBanLocalService;
 
 	private ServiceRegistration<PortletResourcePermission> _serviceRegistration;
 


### PR DESCRIPTION
Hey @Preston-Crary could you give me a hand with a new integration test regarding permission that is failing? I created 2 integration tests to ensure that the issue is fixed and one of them is failing and I don't fully understand why, but I think it might be related to an issue in the permission infrastructure not handling properly the exceptions.

The test `testBannedUserCannotAddRootMessage` throws the exception I'm expecting `com.liferay.portal.kernel.security.auth.PrincipalException$MustHavePermission` but the other test `testBannedUserCannotAddMessageInCategory` throws `java.lang.reflect.UndeclaredThrowableException` I'm getting this error when I run the MBMessageServiceTest

```
com.liferay.message.boards.service.test.MBMessageServiceTest > testBannedUserCannotAddMessageInCategory FAILED
    java.lang.Exception: Unexpected exception, expected<com.liferay.portal.kernel.security.auth.PrincipalException$MustHavePermission> but was<java.lang.reflect.UndeclaredThrowableException>
        at org.junit.internal.runners.statements.ExpectException.evaluate(ExpectException.java:28)
        at org.jboss.arquillian.junit.Arquillian$7.evaluate(Arquillian.java:321)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
        at org.jboss.arquillian.junit.Arquillian$2.evaluate(Arquillian.java:204)
        at org.jboss.arquillian.junit.Arquillian.multiExecute(Arquillian.java:422)
        at org.jboss.arquillian.junit.Arquillian.access$200(Arquillian.java:54)
        at org.jboss.arquillian.junit.Arquillian$3.evaluate(Arquillian.java:218)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
        at org.jboss.arquillian.junit.Arquillian.run(Arquillian.java:166)
        at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.runTestClass(JUnitTestClassExecuter.java:114)
        at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.execute(JUnitTestClassExecuter.java:57)
        at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassProcessor.processTestClass(JUnitTestClassProcessor.java:66)
        at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
        at sun.reflect.GeneratedMethodAccessor3.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:32)
        at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
        at com.sun.proxy.$Proxy3.processTestClass(Unknown Source)
        at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:109)
        at sun.reflect.GeneratedMethodAccessor2.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:377)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:54)
        at org.gradle.internal.concurrent.StoppableExecutorImpl$1.run(StoppableExecutorImpl.java:40)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)

        Caused by:
        java.lang.reflect.UndeclaredThrowableException
            at com.sun.proxy.$Proxy131.check(Unknown Source)
            at com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionHelper.check(ModelResourcePermissionHelper.java:39)
            at com.liferay.message.boards.service.impl.MBMessageServiceImpl.addMessage(MBMessageServiceImpl.java:108)
            at sun.reflect.GeneratedMethodAccessor2401.invoke(Unknown Source)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at com.liferay.portal.spring.aop.ServiceBeanMethodInvocation.proceed(ServiceBeanMethodInvocation.java:158)
            at com.liferay.portal.spring.transaction.DefaultTransactionExecutor.execute(DefaultTransactionExecutor.java:54)
            at com.liferay.portal.spring.transaction.TransactionInterceptor.invoke(TransactionInterceptor.java:58)
            at com.liferay.portal.spring.aop.ServiceBeanMethodInvocation.proceed(ServiceBeanMethodInvocation.java:135)
            at com.liferay.portal.service.ServiceContextAdvice.invoke(ServiceContextAdvice.java:51)
            at com.liferay.portal.spring.aop.ServiceBeanMethodInvocation.proceed(ServiceBeanMethodInvocation.java:135)
            at com.liferay.portal.spring.aop.ChainableMethodAdvice.invoke(ChainableMethodAdvice.java:56)
            at com.liferay.portal.spring.aop.ServiceBeanMethodInvocation.proceed(ServiceBeanMethodInvocation.java:135)
            at com.liferay.portal.spring.aop.ChainableMethodAdvice.invoke(ChainableMethodAdvice.java:56)
            at com.liferay.portal.spring.aop.ServiceBeanMethodInvocation.proceed(ServiceBeanMethodInvocation.java:135)
            at com.liferay.portal.spring.aop.ChainableMethodAdvice.invoke(ChainableMethodAdvice.java:56)
            at com.liferay.portal.spring.aop.ServiceBeanMethodInvocation.proceed(ServiceBeanMethodInvocation.java:135)
            at com.liferay.portal.spring.aop.ServiceBeanAopProxy.invoke(ServiceBeanAopProxy.java:145)
            at com.sun.proxy.$Proxy1305.addMessage(Unknown Source)
            at com.liferay.message.boards.service.MBMessageServiceUtil.addMessage(MBMessageServiceUtil.java:63)
            at com.liferay.message.boards.service.test.MBMessageServiceTest.testBannedUserCannotAddMessageInCategory(MBMessageServiceTest.java:263)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
            at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
            at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
            at org.jboss.arquillian.junit.Arquillian$8$1.invoke(Arquillian.java:370)
            at org.jboss.arquillian.container.test.impl.execution.LocalTestExecuter.execute(LocalTestExecuter.java:60)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
            at org.jboss.arquillian.core.impl.EventContextImpl.invokeObservers(EventContextImpl.java:99)
            at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:81)
            at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:145)
            at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:116)
            at org.jboss.arquillian.core.impl.EventImpl.fire(EventImpl.java:67)
            at org.jboss.arquillian.container.test.impl.execution.ContainerTestExecuter.execute(ContainerTestExecuter.java:38)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
            at org.jboss.arquillian.core.impl.EventContextImpl.invokeObservers(EventContextImpl.java:99)
            at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:81)
            at com.liferay.arquillian.extension.junit.bridge.observer.JUnitBridgeObserver$1.evaluate(JUnitBridgeObserver.java:61)
            at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
            at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:61)
            at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:61)
            at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:61)
            at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:61)
            at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:61)
            at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:61)
            at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:61)
            at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:61)
            at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:61)
            at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:61)
            at com.liferay.portal.test.rule.LiferayIntegrationTestRule$1$1.evaluate(LiferayIntegrationTestRule.java:155)
            at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:61)
            at org.junit.rules.RunRules.evaluate(RunRules.java:20)
            at com.liferay.arquillian.extension.junit.bridge.observer.JUnitBridgeObserver.evaluateWithClassRule(JUnitBridgeObserver.java:130)
            at com.liferay.arquillian.extension.junit.bridge.observer.JUnitBridgeObserver.aroundTest(JUnitBridgeObserver.java:118)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
            at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:88)
            at com.liferay.arquillian.container.osgi.remote.bundleclasspath.BundleClassPathObserver.suiteEvent(BundleClassPathObserver.java:39)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
            at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:88)
            at org.jboss.arquillian.test.impl.TestContextHandler.createClassContext(TestContextHandler.java:92)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
            at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:88)
            at org.jboss.arquillian.test.impl.TestContextHandler.createSuiteContext(TestContextHandler.java:73)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
            at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:88)
            at org.jboss.arquillian.test.impl.TestContextHandler.createTestContext(TestContextHandler.java:130)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
            at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:88)
            at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:145)
            at org.jboss.arquillian.test.impl.EventTestRunnerAdaptor.test(EventTestRunnerAdaptor.java:136)
            at org.jboss.arquillian.junit.Arquillian$8.evaluate(Arquillian.java:363)
            at org.junit.internal.runners.statements.ExpectException.evaluate(ExpectException.java:19)
            at org.jboss.arquillian.junit.Arquillian$7$1.invoke(Arquillian.java:315)
            at org.jboss.arquillian.container.test.impl.execution.BeforeLifecycleEventExecuter.on(BeforeLifecycleEventExecuter.java:35)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
            at org.jboss.arquillian.core.impl.EventContextImpl.invokeObservers(EventContextImpl.java:99)
            at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:81)
            at com.liferay.arquillian.container.osgi.remote.bundleclasspath.BundleClassPathObserver.suiteEvent(BundleClassPathObserver.java:39)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
            at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:88)
            at org.jboss.arquillian.test.impl.TestContextHandler.createClassContext(TestContextHandler.java:92)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
            at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:88)
            at org.jboss.arquillian.test.impl.TestContextHandler.createSuiteContext(TestContextHandler.java:73)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
            at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:88)
            at org.jboss.arquillian.test.impl.TestContextHandler.createTestContext(TestContextHandler.java:130)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:94)
            at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:88)
            at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:145)
            at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:116)
            at org.jboss.arquillian.test.impl.EventTestRunnerAdaptor.fireCustomLifecycle(EventTestRunnerAdaptor.java:159)
            at org.jboss.arquillian.junit.Arquillian$7.evaluate(Arquillian.java:311)
            at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
            at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
            at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
            at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
            at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
            at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
            at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
            at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
            at org.jboss.arquillian.junit.Arquillian$2.evaluate(Arquillian.java:204)
            at org.jboss.arquillian.junit.Arquillian.multiExecute(Arquillian.java:422)
            at org.jboss.arquillian.junit.Arquillian.access$200(Arquillian.java:54)
            at org.jboss.arquillian.junit.Arquillian$3.evaluate(Arquillian.java:218)
            at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
            at org.jboss.arquillian.junit.Arquillian.run(Arquillian.java:166)
            at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
            at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
            at org.jboss.arquillian.junit.container.JUnitTestRunner.execute(JUnitTestRunner.java:66)
            at org.jboss.arquillian.protocol.jmx.JMXTestRunner.doRunTestMethod(JMXTestRunner.java:180)
            at org.jboss.arquillian.protocol.jmx.JMXTestRunner.runTestMethodInternal(JMXTestRunner.java:162)
            at org.jboss.arquillian.protocol.jmx.JMXTestRunner.runTestMethod(JMXTestRunner.java:120)
            at com.liferay.arquillian.container.osgi.remote.activator.ArquillianBundleActivator$2.runTestMethod(ArquillianBundleActivator.java:80)
            at org.jboss.arquillian.protocol.jmx.JMXTestRunner.runTestMethod(JMXTestRunner.java:137)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at sun.reflect.misc.Trampoline.invoke(MethodUtil.java:71)
            at sun.reflect.GeneratedMethodAccessor2561.invoke(Unknown Source)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at sun.reflect.misc.MethodUtil.invoke(MethodUtil.java:275)
            at com.sun.jmx.mbeanserver.StandardMBeanIntrospector.invokeM2(StandardMBeanIntrospector.java:112)
            at com.sun.jmx.mbeanserver.StandardMBeanIntrospector.invokeM2(StandardMBeanIntrospector.java:46)
            at com.sun.jmx.mbeanserver.MBeanIntrospector.invokeM(MBeanIntrospector.java:237)
            at com.sun.jmx.mbeanserver.PerInterface.invoke(PerInterface.java:138)
            at com.sun.jmx.mbeanserver.MBeanSupport.invoke(MBeanSupport.java:252)
            at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:819)
            at com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:801)
            at javax.management.remote.rmi.RMIConnectionImpl.doOperation(RMIConnectionImpl.java:1468)
            at javax.management.remote.rmi.RMIConnectionImpl.access$300(RMIConnectionImpl.java:76)
            at javax.management.remote.rmi.RMIConnectionImpl$PrivilegedOperation.run(RMIConnectionImpl.java:1309)
            at javax.management.remote.rmi.RMIConnectionImpl.doPrivilegedOperation(RMIConnectionImpl.java:1401)
            at javax.management.remote.rmi.RMIConnectionImpl.invoke(RMIConnectionImpl.java:829)
            at sun.reflect.GeneratedMethodAccessor2560.invoke(Unknown Source)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:324)
            at sun.rmi.transport.Transport$1.run(Transport.java:200)
            at sun.rmi.transport.Transport$1.run(Transport.java:197)
            at java.security.AccessController.doPrivileged(Native Method)
            at sun.rmi.transport.Transport.serviceCall(Transport.java:196)
            at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:568)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:826)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:683)
            at java.security.AccessController.doPrivileged(Native Method)
            at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:682)
            ... 3 more

            Caused by:
            java.lang.reflect.InvocationTargetException
                at sun.reflect.GeneratedMethodAccessor2406.invoke(Unknown Source)
                at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
                at java.lang.reflect.Method.invoke(Method.java:498)
                at com.liferay.portal.kernel.util.ServiceProxyFactory$AwaitServiceInvocationHandler.invoke(ServiceProxyFactory.java:238)
                ... 204 more

                Caused by:
                com.liferay.portal.kernel.security.auth.PrincipalException$MustHavePermission: User 43135 must have ADD_MESSAGE permission for com.liferay.message.boards.model.MBCategory 43204
                    at com.liferay.portal.kernel.internal.security.permission.resource.DefaultModelResourcePermission.check(DefaultModelResourcePermission.java:54)
                    ... 208 more
```

Let me know if you have any idea what might be causing this.

Thanks!