### PR TITLE
LPS-83181 Use Character.isSpaceChar to detect nbsp;

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -3449,7 +3449,7 @@ public class StringUtil {
 		for (int j = curLength - suffix.length() + 1, offset; j > 0; j--) {
 			offset = s.offsetByCodePoints(0, j);
 
-			if (Character.isWhitespace(s.codePointBefore(offset))) {
+			if (Character.isSpaceChar(s.codePointBefore(offset))) {
 				curLength = j - 1;
 
 				break;


### PR DESCRIPTION
/cc @joshuacords

Notes from Josh:
> https://issues.liferay.com/browse/LPS-83181
> 
> The root of this problem is the body of the Message Board contained "&-nbsp;" as it's whitespace and the StringUtil.shorten() method does not see "&-nbsp;" as a place to break, so it just defaults to cutting the text at the character limit.
> 
> StringUtil used Character.isWhitespace() to find word ends when shortening text, however that method looks for what Java considers a space and will not find non-breaking spaces as is stated in it's [description](https://docs.oracle.com/javase/7/docs/api/java/lang/Character.html#isWhitespace(char)). The better method to use is Character.isSpaceChar() which finds whitespace characters based on Unicode standards which is more appropriate, description [here](https://docs.oracle.com/javase/7/docs/api/java/lang/Character.html#isSpaceChar(char)). 