### PR TITLE
[TS] LPS-85437

### DIFF
--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -515,6 +515,12 @@
 	</filter-mapping>
 	<filter-mapping>
 		<filter-name>Auto Login Filter</filter-name>
+		<url-pattern>/c/portal/saml/auth_redirect</url-pattern>
+		<dispatcher>FORWARD</dispatcher>
+		<dispatcher>REQUEST</dispatcher>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>Auto Login Filter</filter-name>
 		<url-pattern>/c/portal/update_password</url-pattern>
 		<dispatcher>FORWARD</dispatcher>
 		<dispatcher>REQUEST</dispatcher>


### PR DESCRIPTION
In the case of saml login, once returned from idp server, and if the requested resource does not have a url pattern that is pre-defined (for example /c/portal/layout), the auto login filter will not be triggered and user will not be logged in. Thus giving it saml/auth_redirect path so that auto login filter will be triggered for every saml redirect