### PR TITLE
Lps 86482

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -237,24 +237,6 @@ public class HtmlImpl implements Html {
 				if (!_VALID_CHARS[c]) {
 					String replacement = null;
 
-					if (mode == ESCAPE_MODE_ATTRIBUTE) {
-						if (c == CharPool.AMPERSAND) {
-							replacement = StringPool.AMPERSAND_ENCODED;
-						}
-						else if (c == CharPool.APOSTROPHE) {
-							replacement = "&#39;";
-						}
-						else if (c == CharPool.QUOTE) {
-							replacement = "&quot;";
-						}
-						else if (!_isValidXmlCharacter(c)) {
-							replacement = StringPool.SPACE;
-						}
-						else {
-							continue;
-						}
-					}
-
 					if (sb == null) {
 						sb = new StringBuilder(text.length() + 64);
 					}
@@ -263,26 +245,21 @@ public class HtmlImpl implements Html {
 						sb.append(text, lastReplacementIndex, i);
 					}
 
-					if (replacement != null) {
-						sb.append(replacement);
-					}
-					else {
-						sb.append(prefix);
+					sb.append(prefix);
 
-						_appendHexChars(sb, hexBuffer, c);
+					_appendHexChars(sb, hexBuffer, c);
 
-						sb.append(postfix);
+					sb.append(postfix);
 
-						if ((mode == ESCAPE_MODE_CSS) &&
-							(i < (text.length() - 1))) {
+					if ((mode == ESCAPE_MODE_CSS) &&
+						(i < (text.length() - 1))) {
 
-							char nextChar = text.charAt(i + 1);
+						char nextChar = text.charAt(i + 1);
 
-							if ((nextChar >= CharPool.NUMBER_0) &&
-								(nextChar <= CharPool.NUMBER_9)) {
+						if ((nextChar >= CharPool.NUMBER_0) &&
+							(nextChar <= CharPool.NUMBER_9)) {
 
-								sb.append(CharPool.SPACE);
-							}
+							sb.append(CharPool.SPACE);
 						}
 					}
 

--- a/portal-impl/test/unit/com/liferay/portal/util/HtmlImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/HtmlImplTest.java
@@ -95,25 +95,25 @@ public class HtmlImplTest {
 		Assert.assertEquals(
 			StringPool.BLANK, _htmlImpl.escapeHREF(StringPool.BLANK));
 		Assert.assertEquals(
-			"javascript%3aalert(&#39;hello&#39;);",
+			"javascript&#x25;3aalert&#x28;&#x27;hello&#x27;&#x29;&#x3b;",
 			_htmlImpl.escapeHREF("javascript:alert('hello');"));
 		Assert.assertEquals(
-			"data%3atext/html;base64,PHNjcmlwdD5hbGVydCgndGVzdDMnKTwvc2NyaX" +
-				"B0Pg",
+			"data&#x25;3atext&#x2f;html&#x3b;base64&#x2c;PHNjcmlwdD5hbGVydCgn" +
+				"dGVzdDMnKTwvc2NyaXB0Pg",
 			_htmlImpl.escapeHREF(
 				"data:text/html;base64,PHNjcmlwdD5hbGVydCgndGVzdDMnKTwvc2NyaX" +
 					"B0Pg"));
 		Assert.assertEquals(
-			"http://localhost:8080",
+			"http&#x3a;&#x2f;&#x2f;localhost&#x3a;8080",
 			_htmlImpl.escapeHREF("http://localhost:8080"));
 		Assert.assertEquals(
-			"javascript\t%3aalert(1)",
+			"javascript&#x09;&#x25;3aalert&#x28;1&#x29;",
 			_htmlImpl.escapeHREF("javascript\t:alert(1)"));
 		Assert.assertEquals(
-			"java script%3aalert(1)",
+			"java&#x20;script&#x25;3aalert&#x28;1&#x29;",
 			_htmlImpl.escapeHREF("java script:alert(1)"));
 		Assert.assertEquals(
-			"java\nscript %3aalert(1)",
+			"java&#x0a;script&#x20;&#x25;3aalert&#x28;1&#x29;",
 			_htmlImpl.escapeHREF("java\nscript :alert(1)"));
 	}
 


### PR DESCRIPTION
Resending this from https://github.com/shuyangzhou/liferay-portal/pull/6929 with the dead code removed as per your suggestion.

As for why we're making this change, the behavior in the specific commit that I partially reverted from LPS-73238 caused over-escaping in templates that ended up removing new line characters, getting rid of the intended formatting. The only thing that I was ever able to find that caused this was how we were escaping the text, so I reverted just enough to resolve my issue while leaving the rest of the fix as intact as possible.

Please let me know if you need any further clarification or explanation in regards to this fix. 

Also note this fix was also fully reverted in 7.0.x to fix a separate issue.