### PR TITLE
LPS-85870 PortletRequestDispatcher.forward(RenderRequest,RenderResponse) does not forward to resources such as plain HTML document files

### DIFF
--- a/portal-impl/src/com/liferay/portlet/internal/PortletRequestDispatcherImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletRequestDispatcherImpl.java
@@ -239,9 +239,27 @@ public class PortletRequestDispatcherImpl
 			}
 
 			if (servletPath == null) {
+				int extensionIndex = pathNoQueryString.lastIndexOf(
+					CharPool.PERIOD);
+
+				if (extensionIndex >= 0) {
+					for (String urlPattern : servletURLPatterns) {
+						if (urlPattern.startsWith("*.") &&
+							pathNoQueryString.regionMatches(
+								extensionIndex, urlPattern, 1,
+								urlPattern.length() - 1)) {
+
+							servletPath = pathNoQueryString;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (servletPath == null) {
 				if (!include &&
-					!(pathNoQueryString.endsWith(".jsp") ||
-					  pathNoQueryString.endsWith(".jspx"))) {
+					!servletURLPatterns.contains(pathNoQueryString)) {
 
 					pathInfo = pathNoQueryString;
 				}

--- a/portal-impl/src/com/liferay/portlet/internal/PortletRequestDispatcherImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletRequestDispatcherImpl.java
@@ -39,6 +39,7 @@ import com.liferay.portlet.PortletServletResponse;
 import java.io.IOException;
 
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -219,7 +220,11 @@ public class PortletRequestDispatcherImpl
 
 			PortletApp portletApp = portlet.getPortletApp();
 
-			Set<String> servletURLPatterns = portletApp.getServletURLPatterns();
+			Set<String> servletURLPatterns = new LinkedHashSet<>(
+				portletApp.getServletURLPatterns());
+
+			servletURLPatterns.add("*.jsp");
+			servletURLPatterns.add("*.jspx");
 
 			for (String urlPattern : servletURLPatterns) {
 				if (urlPattern.endsWith("/*")) {


### PR DESCRIPTION
@Preston-Crary: I reviewed your commits and they are a nice solution. I added one commit on top to handle dispatching to the .jsp and .jspx "implied" servlet-mappings. I also updated the [LPS-85870](https://issues.liferay.com/browse/LPS-85870) ticket with a new version of the com.liferay.test.lps85870.war reproducer portlet so that you can test the commits with HTML and JSP.

Please review when you get an opportunity and pass along to Shuyang if you are satisfied. Thanks.