### PR TITLE
[TS] LPS-92784

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1144,7 +1144,9 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		// Organizations
 
-		updateOrganizations(userId, organizationIds, false);
+		if (organizationIds != null) {
+			userPersistence.setOrganizations(userId, organizationIds);
+		}
 
 		// Roles
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-92784

When attempting to add a new user to an org which already has existing users, the time it takes to add the new user scales up depending on how many users already belong to said org.  Time goes up approximately 1 second per 20000 users.

The root cause is how long the Users_Orgs table mapping takes to iterate over all matches from the given SELECT statement.  Currently, we are selecting all userIds which belong to the given organizationID, then determining if any match the newly added user (they never will because the user is brand-new).  As the number of users belonging to the org increases, so does the time it takes to retrieve all userIds.

Since we are not able to blindly add an entry to the Users_Orgs table, the solution will be to essentially reverse the query.  Instead of retrieving userIds belonging to the organizationId, we will retrieve organizationIds which belong to the new user's userId (this will always return 0, and is thus very fast and still achieves the same result we want).

Let me know if you have any questions, thanks!