### PR TITLE
[TS] LPS-92784

### DIFF
--- a/modules/apps/subscription/subscription-service/src/main/java/com/liferay/subscription/internal/messaging/CleanUpUserSubscriptionMessageListener.java
+++ b/modules/apps/subscription/subscription-service/src/main/java/com/liferay/subscription/internal/messaging/CleanUpUserSubscriptionMessageListener.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.subscription.internal.messaging;
+
+import com.liferay.portal.kernel.messaging.BaseMessageListener;
+import com.liferay.portal.kernel.messaging.DestinationNames;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.subscription.service.SubscriptionLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Christopher Kian
+ */
+@Component(
+	immediate = true,
+	property = "destination.name=" + DestinationNames.USER_SUBSCRIPTION_CLEAN_UP,
+	service = MessageListener.class
+)
+public class CleanUpUserSubscriptionMessageListener
+	extends BaseMessageListener {
+
+	@Override
+	protected void doReceive(Message message) throws Exception {
+		long[] groupIds = (long[])message.get("groupIds");
+		long userId = (Long)message.get("userId");
+
+		for (long groupId : groupIds) {
+			_subscriptionLocalService.deleteSubscriptions(userId, groupId);
+		}
+	}
+
+	@Reference(unbind = "-")
+	protected void setSubscriptionLocalService(
+		SubscriptionLocalService subscriptionLocalService) {
+
+		_subscriptionLocalService = subscriptionLocalService;
+	}
+
+	private SubscriptionLocalService _subscriptionLocalService;
+
+}

--- a/portal-impl/src/META-INF/messaging-misc-spring.xml
+++ b/portal-impl/src/META-INF/messaging-misc-spring.xml
@@ -115,6 +115,12 @@
 						<util:constant static-field="com.liferay.portal.kernel.messaging.DestinationConfiguration.DESTINATION_TYPE_PARALLEL" />
 					</constructor-arg>
 				</bean>
+				<bean class="com.liferay.portal.kernel.messaging.DestinationConfiguration">
+					<constructor-arg name="destinationName" value="liferay/user_subscription_clean_up" />
+					<constructor-arg name="destinationType">
+						<util:constant static-field="com.liferay.portal.kernel.messaging.DestinationConfiguration.DESTINATION_TYPE_PARALLEL" />
+					</constructor-arg>
+				</bean>
 			</util:set>
 		</property>
 		<property name="messageListeners">

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -6740,11 +6740,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			unsetUserOrganizations(userId, oldOrganizationIds);
 		}
 
-		for (long newOrganizationId : newOrganizationIds) {
-			if (!ArrayUtil.contains(oldOrganizationIds, newOrganizationId)) {
-				addOrganizationUsers(newOrganizationId, new long[] {userId});
-			}
-		}
+		userPersistence.setOrganizations(userId, newOrganizationIds);
 
 		if (indexingEnabled) {
 			reindex(userId);

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -6677,10 +6677,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			long userId, long[] newOrganizationIds, boolean indexingEnabled)
 		throws PortalException {
 
-		if (newOrganizationIds == null) {
-			return;
-		}
-
 		long[] oldOrganizationIds = getOrganizationPrimaryKeys(userId);
 
 		for (long oldOrganizationId : oldOrganizationIds) {

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/DestinationNames.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/DestinationNames.java
@@ -130,6 +130,9 @@ public interface DestinationNames {
 
 	public static final String TEST_TRANSACTION = "liferay/test_transaction";
 
+	public static final String USER_SUBSCRIPTION_CLEAN_UP =
+		"liferay/user_subscription_clean_up";
+
 	public static final String WORKFLOW_COMPARATOR =
 		"liferay/workflow_comparator";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/messaging/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/messaging/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
@@ -2140,6 +2140,15 @@ public interface UserLocalService
 		throws PortalException;
 
 	/**
+	 * Removes the user from the organizations.
+	 *
+	 * @param userId the primary key of the user
+	 * @param organizationIds the primary keys of the organizations
+	 */
+	public void unsetUserOrganizations(long userId, long[] organizationIds)
+		throws PortalException;
+
+	/**
 	 * Updates whether the user has agreed to the terms of use.
 	 *
 	 * @param userId the primary key of the user

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
@@ -2811,6 +2811,19 @@ public class UserLocalServiceUtil {
 	}
 
 	/**
+	 * Removes the user from the organizations.
+	 *
+	 * @param userId the primary key of the user
+	 * @param organizationIds the primary keys of the organizations
+	 */
+	public static void unsetUserOrganizations(
+			long userId, long[] organizationIds)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		getService().unsetUserOrganizations(userId, organizationIds);
+	}
+
+	/**
 	 * Updates whether the user has agreed to the terms of use.
 	 *
 	 * @param userId the primary key of the user

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
@@ -2991,6 +2991,19 @@ public class UserLocalServiceWrapper
 	}
 
 	/**
+	 * Removes the user from the organizations.
+	 *
+	 * @param userId the primary key of the user
+	 * @param organizationIds the primary keys of the organizations
+	 */
+	@Override
+	public void unsetUserOrganizations(long userId, long[] organizationIds)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_userLocalService.unsetUserOrganizations(userId, organizationIds);
+	}
+
+	/**
 	 * Updates whether the user has agreed to the terms of use.
 	 *
 	 * @param userId the primary key of the user


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-92784

I decided it would be best to clean up and fix the method rather than just fixing my use-case only.  I've tested the changes and made sure everything happens as needed (Roles, Orgs, and Subscriptions are removed).  Let me know if you have any questions, thanks!

Original comment:

> When attempting to add a new user to an org which already has existing users, the time it takes to add the new user scales up depending on how many users already belong to said org. Time goes up approximately 1 second per 20000 users.
> 
> The root cause is how long the Users_Orgs table mapping takes to iterate over all matches from the given SELECT statement. Currently, we are selecting all userIds which belong to the given organizationID, then determining if any match the newly added user (they never will because the user is brand-new). As the number of users belonging to the org increases, so does the time it takes to retrieve all userIds.
> 
> Since we are not able to blindly add an entry to the Users_Orgs table, the solution will be to essentially reverse the query. Instead of retrieving userIds belonging to the organizationId, we will retrieve organizationIds which belong to the new user's userId (this will always return 0, and is thus very fast and still achieves the same result we want).
> 
> Let me know if you have any questions, thanks!