### PR TITLE
Lps 89294 1

### DIFF
--- a/modules/apps/export-import/export-import-service/source-formatter-suppressions.xml
+++ b/modules/apps/export-import/export-import-service/source-formatter-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<suppressions>
+	<source-check>
+		<suppress checks="JavaOSGiReferenceCheck" files="src/main/java/com/liferay/exportimport/internal/staging/StagingImpl\.java" />
+	</source-check>
+</suppressions>

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -115,6 +115,7 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.service.LayoutBranchLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
@@ -128,6 +129,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
+import com.liferay.portal.kernel.service.http.TunnelUtil;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.servlet.ServletResponseConstants;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -139,6 +141,8 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.MethodHandler;
+import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
@@ -1900,8 +1904,45 @@ public class StagingImpl implements Staging {
 		boolean secureConnection = GetterUtil.getBoolean(
 			typeSettingsProperties.getProperty("secureConnection"));
 
-		String groupDisplayURL = GroupServiceHttp.getGroupDisplayURL(
-			httpPrincipal, remoteGroupId, privateLayout, secureConnection);
+		String groupDisplayURL;
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				GroupServiceUtil.class, "getGroupDisplayURL",
+				_GET_GROUP_DISPLAY_URL_PARAMETER_TYPES);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, remoteGroupId, privateLayout, secureConnection);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof PortalException) {
+					throw (PortalException)e;
+				}
+
+				throw new SystemException(e);
+			}
+
+			groupDisplayURL = (String)returnObj;
+		}
+		catch (SystemException se) {
+			if (se.getCause() instanceof ConnectException) {
+				_log.error("Connection error: " + se.getMessage());
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(se, se);
+				}
+			}
+			else {
+				_log.error(se, se);
+			}
+
+			throw se;
+		}
 
 		try {
 			URL remoteSiteURL = new URL(groupDisplayURL);
@@ -3547,8 +3588,39 @@ public class StagingImpl implements Staging {
 			// Ping the remote host and verify that the remote group exists in
 			// the same company as the remote user
 
-			GroupServiceHttp.checkRemoteStagingGroup(
-				httpPrincipal, remoteGroupId);
+			try {
+				MethodKey methodKey = new MethodKey(
+					GroupServiceUtil.class, "checkRemoteStagingGroup",
+					_CHECK_REMOTE_STAGING_GROUP_PARAMETER_TYPES);
+
+				MethodHandler methodHandler = new MethodHandler(
+					methodKey, remoteGroupId);
+
+				try {
+					TunnelUtil.invoke(httpPrincipal, methodHandler);
+				}
+				catch (Exception e) {
+					if (e instanceof PortalException) {
+						throw (PortalException)e;
+					}
+
+					throw new SystemException(e);
+				}
+			}
+			catch (SystemException se) {
+				if (se.getCause() instanceof ConnectException) {
+					_log.error("Connection error: " + se.getMessage());
+
+					if (_log.isDebugEnabled()) {
+						_log.debug(se, se);
+					}
+				}
+				else {
+					_log.error(se, se);
+				}
+
+				throw se;
+			}
 
 			Group group = _groupLocalService.getGroup(groupId);
 
@@ -4185,6 +4257,14 @@ public class StagingImpl implements Staging {
 
 		_groupLocalService.updateGroup(group);
 	}
+
+	private static final Class<?>[]
+		_CHECK_REMOTE_STAGING_GROUP_PARAMETER_TYPES = new Class<?>[] {
+			long.class
+		};
+
+	private static final Class<?>[] _GET_GROUP_DISPLAY_URL_PARAMETER_TYPES =
+		new Class<?>[] {long.class, boolean.class, boolean.class};
 
 	private static final Log _log = LogFactoryUtil.getLog(StagingImpl.class);
 

--- a/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/action/EditPublishConfigurationMVCActionCommand.java
+++ b/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/action/EditPublishConfigurationMVCActionCommand.java
@@ -17,6 +17,7 @@ package com.liferay.staging.processes.web.internal.portlet.action;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationConstants;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationFactory;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationHelper;
+import com.liferay.exportimport.kernel.exception.RemoteExportException;
 import com.liferay.exportimport.kernel.lar.ExportImportHelper;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
@@ -44,6 +45,8 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.staging.constants.StagingProcessesPortletKeys;
 import com.liferay.taglib.ui.util.SessionTreeJSClicks;
 import com.liferay.trash.service.TrashEntryService;
+
+import java.net.ConnectException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -159,7 +162,18 @@ public class EditPublishConfigurationMVCActionCommand
 			sendRedirect(actionRequest, actionResponse, redirect);
 		}
 		catch (Exception e) {
-			_log.error(e, e);
+			if (e instanceof ConnectException ||
+				e instanceof RemoteExportException) {
+
+				_log.error("Connection error: " + e.getMessage());
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(e, e);
+				}
+			}
+			else {
+				_log.error(e, e);
+			}
 
 			SessionErrors.add(actionRequest, e.getClass(), e);
 		}

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -93,7 +93,9 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.security.permission.RolePermissions;
 import com.liferay.portal.kernel.security.permission.UserBag;
+import com.liferay.portal.kernel.service.GroupService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.http.TunnelUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.transaction.Transactional;
@@ -107,6 +109,8 @@ import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.MethodHandler;
+import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
@@ -133,6 +137,8 @@ import com.liferay.util.dao.orm.CustomSQLUtil;
 
 import java.io.File;
 import java.io.Serializable;
+
+import java.net.ConnectException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -5079,8 +5085,39 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			// Ping the remote host and verify that the remote group exists in
 			// the same company as the remote user
 
-			GroupServiceHttp.checkRemoteStagingGroup(
-				httpPrincipal, remoteGroupId);
+			try {
+				MethodKey methodKey = new MethodKey(
+					GroupService.class, "checkRemoteStagingGroup",
+					_CHECK_REMOTE_STAGING_GROUP_PARAMETER_TYPES);
+
+				MethodHandler methodHandler = new MethodHandler(
+					methodKey, remoteGroupId);
+
+				try {
+					TunnelUtil.invoke(httpPrincipal, methodHandler);
+				}
+				catch (Exception e) {
+					if (e instanceof PortalException) {
+						throw (PortalException)e;
+					}
+
+					throw new SystemException(e);
+				}
+			}
+			catch (SystemException se) {
+				if (se.getCause() instanceof ConnectException) {
+					_log.error("Connection error: " + se.getMessage());
+
+					if (_log.isDebugEnabled()) {
+						_log.debug(se, se);
+					}
+				}
+				else {
+					_log.error(se, se);
+				}
+
+				throw se;
+			}
 
 			// Ensure that the local group and the remote group are not the same
 			// group and that they are either both company groups or both not
@@ -5195,6 +5232,11 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 				nameMap.get(defaultLocale), group.isSite());
 		}
 	}
+
+	private static final Class<?>[]
+		_CHECK_REMOTE_STAGING_GROUP_PARAMETER_TYPES = new Class<?>[] {
+			long.class
+		};
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		GroupLocalServiceImpl.class);


### PR DESCRIPTION
/cc @knchau

Notes from Kim:

> https://issues.liferay.com/browse/LPS-89294
> 
> The issue is how we log connection exception errors for a NoConnectionException case. Instead of updating how we log ConnectionExceptions for all `*HTTPService.java` in the template, I handled the ConnectionException for the few, relevant cases related to the issue.
> 
> The added SF suppression is necessary because inlining the method requires passing `Class<?>`, which cannot be done when using the referenced service. 
> 
> This ticket will not affect LPS-94690 and LPS-94690 will not affect this ticket but LPS-94690 will benefit from this ticket because it will shorten the thrown ConnectionException.