### PR TITLE
LPS-110417 Unable to initalize My Account panel permissions after upgrade

### DIFF
--- a/modules/apps/application-list/application-list-my-account-permissions/src/main/java/com/liferay/application/list/my/account/permissions/internal/PanelAppMyAccountPermissions.java
+++ b/modules/apps/application-list/application-list-my-account-permissions/src/main/java/com/liferay/application/list/my/account/permissions/internal/PanelAppMyAccountPermissions.java
@@ -123,7 +123,7 @@ public class PanelAppMyAccountPermissions {
 		return null;
 	}
 
-	private void _initPermissions(
+	private synchronized void _initPermissions(
 			long companyId, String portletId, String rootPortletId,
 			Role userRole, List<String> actionIds)
 		throws Exception {

--- a/modules/apps/application-list/application-list-test/src/testIntegration/java/com/liferay/application/list/my/account/permissions/test/PanelAppMyAccountPermissionsTest.java
+++ b/modules/apps/application-list/application-list-test/src/testIntegration/java/com/liferay/application/list/my/account/permissions/test/PanelAppMyAccountPermissionsTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.WebAppPool;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -88,6 +89,25 @@ public class PanelAppMyAccountPermissionsTest {
 			TestPropsValues.getCompanyId(),
 			PortletKeys.PREFS_OWNER_TYPE_COMPANY, LayoutConstants.DEFAULT_PLID,
 			_testPortletId);
+	}
+
+	@Test
+	public void testAddingPanelAppsFromMultipleThreads() throws Exception {
+		_registerTestPortlet(_testPortletId);
+
+		List<Thread> threads = new ArrayList<>();
+
+		Runnable runnable = () -> _registerTestPanelApp(_testPortletId);
+
+		threads.add(new Thread(runnable));
+		threads.add(new Thread(runnable));
+		threads.add(new Thread(runnable));
+
+		threads.forEach(Thread::start);
+
+		while (!threads.isEmpty()) {
+			threads.removeIf(thread -> !thread.isAlive());
+		}
 	}
 
 	@Test

--- a/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/BeanFilterMethod.java
+++ b/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/BeanFilterMethod.java
@@ -22,6 +22,7 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface BeanFilterMethod {
 
-	public Object invoke(Object... arguments) throws ReflectiveOperationException;
+	public Object invoke(Object... arguments)
+		throws ReflectiveOperationException;
 
 }

--- a/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/BeanPortletMethod.java
+++ b/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/BeanPortletMethod.java
@@ -42,7 +42,8 @@ public interface BeanPortletMethod extends Comparable<BeanPortletMethod> {
 
 	public String getResourceID();
 
-	public Object invoke(Object... arguments) throws ReflectiveOperationException;
+	public Object invoke(Object... arguments)
+		throws ReflectiveOperationException;
 
 	public boolean isEventProcessor(QName qName);
 

--- a/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/BeanPortletMethodWrapper.java
+++ b/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/BeanPortletMethodWrapper.java
@@ -77,7 +77,9 @@ public abstract class BeanPortletMethodWrapper implements BeanPortletMethod {
 	}
 
 	@Override
-	public Object invoke(Object... arguments) throws ReflectiveOperationException {
+	public Object invoke(Object... arguments)
+		throws ReflectiveOperationException {
+
 		return _beanPortletMethod.invoke(arguments);
 	}
 

--- a/modules/apps/static/portal-file-install/portal-file-install-test/src/testIntegration/java/com/liferay/portal/file/install/deploy/test/FileInstallDeployTest.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-test/src/testIntegration/java/com/liferay/portal/file/install/deploy/test/FileInstallDeployTest.java
@@ -142,8 +142,8 @@ public class FileInstallDeployTest {
 			_updateConfiguration(
 				() -> {
 					String content = StringBundler.concat(
-						_TEST_KEY, StringPool.EQUAL, "${", systemTestPropertyKey,
-						"}");
+						_TEST_KEY, StringPool.EQUAL, "${",
+						systemTestPropertyKey, "}");
 
 					Files.write(path, content.getBytes());
 				});


### PR DESCRIPTION
This is an update for [LPS-110417](https://issues.liferay.com/browse/LPS-110417).<br><br>Hey @Preston-Crary, will you please look over my test case and solution for this issue? I'm not entirely sure that this is the best approach, but it's very effective for this case. I know it's possible that the fix should happen in the service layers for both PortletPreferences and ResourcePermissions, but since this issue only seems to appear with multiple threads, and I saw there was a similar solution used in https://issues.liferay.com/browse/LPS-104523, I decided to try synchronizing the method as a start. Let me know what you think. Thanks!<br><br>/cc @pei-jung @alee8888 @ChrisKian @dejuknow @patriciajeanperez