### PR TITLE
[TECHNICAL-SUPPORT] LPS-110424 Single asset publication in a clustered environment

### DIFF
--- a/modules/apps/export-import/export-import-changeset-service/build.gradle
+++ b/modules/apps/export-import/export-import-changeset-service/build.gradle
@@ -5,4 +5,5 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:export-import:export-import-changeset-api")
+	compileOnly project(":apps:portal:portal-aop-api")
 }

--- a/modules/apps/export-import/export-import-changeset-service/src/main/java/com/liferay/exportimport/changeset/internal/manager/ChangesetManagerImpl.java
+++ b/modules/apps/export-import/export-import-changeset-service/src/main/java/com/liferay/exportimport/changeset/internal/manager/ChangesetManagerImpl.java
@@ -68,6 +68,7 @@ public class ChangesetManagerImpl
 		_changesets.put(changesetUuid, changeset);
 	}
 
+	@Clusterable(onMaster = true)
 	@Override
 	public void clearChangesets() {
 		_changesets = new HashMap<>();
@@ -78,16 +79,19 @@ public class ChangesetManagerImpl
 		return ChangesetManager.class.getName();
 	}
 
+	@Clusterable(onMaster = true)
 	@Override
 	public boolean hasChangeset(String changesetUuid) {
 		return _changesets.containsKey(changesetUuid);
 	}
 
+	@Clusterable(onMaster = true)
 	@Override
 	public Optional<Changeset> peekChangeset(String changesetUuid) {
 		return Optional.ofNullable(_changesets.get(changesetUuid));
 	}
 
+	@Clusterable(onMaster = true)
 	@Override
 	public Optional<Changeset> popChangeset(String changesetUuid) {
 		Changeset changeset = _changesets.remove(changesetUuid);
@@ -95,6 +99,7 @@ public class ChangesetManagerImpl
 		return Optional.ofNullable(changeset);
 	}
 
+	@Clusterable(onMaster = true)
 	@Override
 	public long publishChangeset(
 		Changeset changeset, ChangesetEnvironment changesetEnvironment) {

--- a/modules/apps/export-import/export-import-changeset-service/src/main/java/com/liferay/exportimport/changeset/internal/manager/ChangesetManagerImpl.java
+++ b/modules/apps/export-import/export-import-changeset-service/src/main/java/com/liferay/exportimport/changeset/internal/manager/ChangesetManagerImpl.java
@@ -24,11 +24,14 @@ import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSe
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
 import com.liferay.exportimport.kernel.staging.Staging;
+import com.liferay.portal.aop.AopService;
+import com.liferay.portal.kernel.cluster.Clusterable;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 
@@ -47,9 +50,11 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Máté Thurzó
  */
-@Component(immediate = true, service = ChangesetManager.class)
-public class ChangesetManagerImpl implements ChangesetManager {
+@Component(immediate = true, service = AopService.class)
+public class ChangesetManagerImpl
+	implements AopService, ChangesetManager, IdentifiableOSGiService {
 
+	@Clusterable(onMaster = true)
 	@Override
 	public void addChangeset(Changeset changeset) {
 		Objects.nonNull(changeset);
@@ -66,6 +71,11 @@ public class ChangesetManagerImpl implements ChangesetManager {
 	@Override
 	public void clearChangesets() {
 		_changesets = new HashMap<>();
+	}
+
+	@Override
+	public String getOSGiServiceIdentifier() {
+		return ChangesetManager.class.getName();
 	}
 
 	@Override


### PR DESCRIPTION
[LPS-110424](https://issues.liferay.com/browse/LPS-110424)

Hi @Preston-Crary ,

As discussed, I modified Changeset to be completely serializable. It now contains only a single list of StagedModels.
My guess is that the original intention of using Suppliers was to let the background thread load the assets themselves, and not the request thread. Since even single asset publication can contain multiple StagedModels ([multiple versions of the same assets](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/PublishArticleMVCActionCommand.java#L73-L74) and even [publication of folders](https://github.com/liferay/liferay-portal/blob/master/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/portlet/action/PublishFolderMVCActionCommand.java#L55-L58)).
So my change will actually slow down the publication request, making the UI less responsive.
My [previous solution](https://github.com/vendeltoreki/liferay-portal/compare/59b7e2c540378f5e62430d2639890819bf21290f...vendeltoreki:LPS-110424-fix-2) doesn't have this problem, but it doesn't work correctly either: it can publish only one single StagedModel.

Please review my changes.

Thanks,
Vendel