### PR TITLE
LPS-113032 Avoid random byte[] when creating files, tika sometimes fa…

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BlogPostingImageResourceTest.java
@@ -21,7 +21,7 @@ import com.liferay.headless.delivery.client.http.HttpInvoker;
 import com.liferay.headless.delivery.client.problem.Problem;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestDataConstants;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 
@@ -93,11 +93,7 @@ public class BlogPostingImageResourceTest
 	protected Map<String, File> getMultipartFiles() throws Exception {
 		return HashMapBuilder.<String, File>put(
 			"file",
-			() -> {
-				String randomString = RandomTestUtil.randomString();
-
-				return FileUtil.createTempFile(randomString.getBytes());
-			}
+			() -> FileUtil.createTempFile(TestDataConstants.TEST_BYTE_ARRAY)
 		).build();
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/DocumentResourceTest.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestDataConstants;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 
@@ -97,11 +98,7 @@ public class DocumentResourceTest extends BaseDocumentResourceTestCase {
 	protected Map<String, File> getMultipartFiles() throws Exception {
 		return HashMapBuilder.<String, File>put(
 			"file",
-			() -> {
-				String randomString = RandomTestUtil.randomString();
-
-				return FileUtil.createTempFile(randomString.getBytes());
-			}
+			() -> FileUtil.createTempFile(TestDataConstants.TEST_BYTE_ARRAY)
 		).build();
 	}
 


### PR DESCRIPTION
…ils to parse nonsense files.

CC @shuyangzhou @nhpatt