### PR TITLE
LPS-113032 Fix new random byte failures.

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/KnowledgeBaseAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/KnowledgeBaseAttachmentResourceTest.java
@@ -23,6 +23,7 @@ import com.liferay.knowledge.base.service.KBArticleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestDataConstants;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -85,9 +86,7 @@ public class KnowledgeBaseAttachmentResourceTest
 			() -> {
 				File file = new File(_tempFileName);
 
-				String randomString = RandomTestUtil.randomString();
-
-				FileUtil.write(file, randomString.getBytes());
+				FileUtil.write(file, TestDataConstants.TEST_BYTE_ARRAY);
 
 				return file;
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardAttachmentResourceTest.java
@@ -23,6 +23,7 @@ import com.liferay.message.boards.test.util.MBTestUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestDataConstants;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 
@@ -83,9 +84,7 @@ public class MessageBoardAttachmentResourceTest
 			() -> {
 				File file = new File(_tempFileName);
 
-				String randomString = RandomTestUtil.randomString();
-
-				FileUtil.write(file, randomString.getBytes());
+				FileUtil.write(file, TestDataConstants.TEST_BYTE_ARRAY);
 
 				return file;
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageAttachmentResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/WikiPageAttachmentResourceTest.java
@@ -20,6 +20,7 @@ import com.liferay.headless.delivery.client.http.HttpInvoker;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestDataConstants;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.wiki.model.WikiNode;
@@ -89,9 +90,7 @@ public class WikiPageAttachmentResourceTest
 			() -> {
 				File file = new File(_tempFileName);
 
-				String randomString = RandomTestUtil.randomString();
-
-				FileUtil.write(file, randomString.getBytes());
+				FileUtil.write(file, TestDataConstants.TEST_BYTE_ARRAY);
 
 				return file;
 			}


### PR DESCRIPTION
CC @shuyangzhou

@hhuijser can we SF this?  Making files from random bytes can lead to files that cause TIKA errors during indexing.