### PR TITLE
Lps 83456 fix

### DIFF
--- a/modules/apps/alloy/alloy-mvc/bnd.bnd
+++ b/modules/apps/alloy/alloy-mvc/bnd.bnd
@@ -5,6 +5,6 @@ Export-Package:\
 	com.liferay.alloy.mvc,\
 	com.liferay.alloy.mvc.json.web.service
 Import-Package:\
-	com.liferay.portal.kernel.portlet;version="[10.1.0,10.2)",\
+	com.liferay.portal.kernel.portlet;version="[10.2.0,10.3)",\
 	\
 	*

--- a/modules/apps/asset/asset-publisher-web/bnd.bnd
+++ b/modules/apps/asset/asset-publisher-web/bnd.bnd
@@ -2,7 +2,7 @@ Bundle-Name: Liferay Asset Publisher Web
 Bundle-SymbolicName: com.liferay.asset.publisher.web
 Bundle-Version: 4.0.32
 Import-Package:\
-	com.liferay.portal.kernel.portlet;version="[10.1.0,10.2)",\
+	com.liferay.portal.kernel.portlet;version="[10.2.0,10.3)",\
 	\
 	*
 Web-ContextPath: /asset-publisher-web

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
@@ -75,9 +75,11 @@ import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletItem;
 import com.liferay.portal.kernel.model.PortletPreferences;
+import com.liferay.portal.kernel.model.PortletPreferencesIds;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.plugin.Version;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactory;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
@@ -146,14 +148,16 @@ public class PortletImportControllerImpl implements PortletImportController {
 	public void deletePortletData(PortletDataContext portletDataContext)
 		throws Exception {
 
-		long ownerId = PortletKeys.PREFS_OWNER_ID_DEFAULT;
-		int ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
+		PortletPreferencesIds portletPreferencesIds =
+			_portletPreferencesFactory.getPortletPreferencesIds(
+				portletDataContext.getCompanyId(),
+				portletDataContext.getGroupId(), 0,
+				portletDataContext.getPlid(),
+				portletDataContext.getPortletId());
 
 		javax.portlet.PortletPreferences portletPreferences =
 			_portletPreferencesLocalService.fetchPreferences(
-				portletDataContext.getCompanyId(), ownerId, ownerType,
-				portletDataContext.getPlid(),
-				portletDataContext.getPortletId());
+				portletPreferencesIds);
 
 		if (portletPreferences == null) {
 			portletPreferences = new PortletPreferencesImpl();
@@ -163,8 +167,10 @@ public class PortletImportControllerImpl implements PortletImportController {
 
 		if (xml != null) {
 			_portletPreferencesLocalService.updatePreferences(
-				ownerId, ownerType, portletDataContext.getPlid(),
-				portletDataContext.getPortletId(), xml);
+				portletPreferencesIds.getOwnerId(),
+				portletPreferencesIds.getOwnerType(),
+				portletPreferencesIds.getPlid(),
+				portletPreferencesIds.getPortletId(), xml);
 		}
 	}
 
@@ -324,14 +330,16 @@ public class PortletImportControllerImpl implements PortletImportController {
 			PortletDataContext portletDataContext, Element portletDataElement)
 		throws Exception {
 
-		long ownerId = PortletKeys.PREFS_OWNER_ID_DEFAULT;
-		int ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
+		PortletPreferencesIds portletPreferencesIds =
+			_portletPreferencesFactory.getPortletPreferencesIds(
+				portletDataContext.getCompanyId(),
+				portletDataContext.getGroupId(), 0,
+				portletDataContext.getPlid(),
+				portletDataContext.getPortletId());
 
 		javax.portlet.PortletPreferences portletPreferences =
 			_portletPreferencesLocalService.fetchPreferences(
-				portletDataContext.getCompanyId(), ownerId, ownerType,
-				portletDataContext.getPlid(),
-				portletDataContext.getPortletId());
+				portletPreferencesIds);
 
 		if (portletPreferences == null) {
 			portletPreferences = new PortletPreferencesImpl();
@@ -342,8 +350,10 @@ public class PortletImportControllerImpl implements PortletImportController {
 
 		if (Validator.isNotNull(xml)) {
 			_portletPreferencesLocalService.updatePreferences(
-				ownerId, ownerType, portletDataContext.getPlid(),
-				portletDataContext.getPortletId(), xml);
+				portletPreferencesIds.getOwnerId(),
+				portletPreferencesIds.getOwnerType(),
+				portletPreferencesIds.getPlid(),
+				portletPreferencesIds.getPortletId(), xml);
 		}
 	}
 
@@ -1552,6 +1562,9 @@ public class PortletImportControllerImpl implements PortletImportController {
 
 	@Reference
 	private PortletLocalService _portletLocalService;
+
+	@Reference
+	private PortletPreferencesFactory _portletPreferencesFactory;
 
 	private PortletPreferencesLocalService _portletPreferencesLocalService;
 	private UserLocalService _userLocalService;

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/controller/test/PortletImportControllerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/controller/test/PortletImportControllerTest.java
@@ -74,10 +74,9 @@ public class PortletImportControllerTest extends BaseExportImportTestCase {
 			group, lastPublishDate, null);
 
 		Assert.assertEquals(
-			PortletKeys.PREFS_OWNER_ID_DEFAULT,
-			portletPreferencesImpl.getOwnerId());
+			group.getGroupId(), portletPreferencesImpl.getOwnerId());
 		Assert.assertEquals(
-			PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+			PortletKeys.PREFS_OWNER_TYPE_GROUP,
 			portletPreferencesImpl.getOwnerType());
 		Assert.assertEquals(
 			LayoutConstants.DEFAULT_PLID, portletPreferencesImpl.getPlid());
@@ -90,12 +89,10 @@ public class PortletImportControllerTest extends BaseExportImportTestCase {
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.getStrictPortletSetup(
 				importedGroup.getCompanyId(), importedGroup.getGroupId(),
-				BookmarksPortletKeys.BOOKMARKS);
+				BookmarksPortletKeys.BOOKMARKS_ADMIN);
 
-		Assert.assertEquals(
-			Long.valueOf(lastPublishDate.getTime()),
-			Long.valueOf(
-				portletPreferences.getValue("last-publish-date", null)));
+		Assert.assertNull(
+			portletPreferences.getValue("last-publish-date", null));
 	}
 
 	@Test
@@ -213,7 +210,7 @@ public class PortletImportControllerTest extends BaseExportImportTestCase {
 			portletPreferences =
 				PortletPreferencesFactoryUtil.getStrictPortletSetup(
 					group.getCompanyId(), group.getGroupId(),
-					BookmarksPortletKeys.BOOKMARKS);
+					BookmarksPortletKeys.BOOKMARKS_ADMIN);
 		}
 		else {
 			portletPreferences =

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/bnd.bnd
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/bnd.bnd
@@ -2,7 +2,7 @@ Bundle-Name: Liferay Layout Type Controller Asset Display
 Bundle-SymbolicName: com.liferay.layout.type.controller.asset.display
 Bundle-Version: 3.0.11
 Import-Package:\
-	com.liferay.portal.kernel.portlet;version="[10.1.0,10.2)",\
+	com.liferay.portal.kernel.portlet;version="[10.2.0,10.3)",\
 	\
 	*
 Web-ContextPath: /layout-type-controller-asset-display

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/bnd.bnd
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/bnd.bnd
@@ -2,7 +2,7 @@ Bundle-Name: Liferay Layout Type Controller Display Page
 Bundle-SymbolicName: com.liferay.layout.type.controller.display.page
 Bundle-Version: 2.0.19
 Import-Package:\
-	com.liferay.portal.kernel.portlet;version="[10.1.0,10.2)",\
+	com.liferay.portal.kernel.portlet;version="[10.2.0,10.3)",\
 	\
 	*
 Web-ContextPath: /layout-type-controller-display-page

--- a/modules/apps/portal/portal-monitoring/bnd.bnd
+++ b/modules/apps/portal/portal-monitoring/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Portal Monitoring
 Bundle-SymbolicName: com.liferay.portal.monitoring
 Bundle-Version: 8.0.12
 Import-Package:\
-	com.liferay.portal.kernel.portlet;version="[10.1.0,10.2)",\
+	com.liferay.portal.kernel.portlet;version="[10.2.0,10.3)",\
 	\
 	*

--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
@@ -773,7 +773,7 @@ public class PortletPreferencesFactoryImpl
 		}
 
 		long ownerId = PortletKeys.PREFS_OWNER_ID_DEFAULT;
-		int ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
+		int ownerType = 0;
 
 		Group group = GroupLocalServiceUtil.fetchGroup(siteGroupId);
 
@@ -800,11 +800,15 @@ public class PortletPreferencesFactoryImpl
 
 			ownerType = PortletKeys.PREFS_OWNER_TYPE_GROUP;
 		}
-		else {
+		else if (companyWide) {
 			plid = PortletKeys.PREFS_PLID_SHARED;
 
 			ownerId = companyId;
 			ownerType = PortletKeys.PREFS_OWNER_TYPE_COMPANY;
+		}
+
+		if ((ownerType == 0) || ((ownerId == 0) && (plid == 0))) {
+			return null;
 		}
 
 		if (strictMode) {

--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
@@ -462,6 +462,68 @@ public class PortletPreferencesFactoryImpl
 
 	@Override
 	public PortletPreferencesIds getPortletPreferencesIds(
+			long companyId, long siteGroupId, long layoutGroupId, long plid,
+			String portletId)
+		throws IllegalArgumentException {
+
+		String originalPortletId = portletId;
+
+		Portlet portlet = PortletLocalServiceUtil.getPortletById(
+			companyId, portletId);
+
+		boolean uniquePerLayout = portlet.isPreferencesUniquePerLayout();
+		boolean ownedByGroup = portlet.isPreferencesOwnedByGroup();
+		boolean companyWide = portlet.isPreferencesCompanyWide();
+
+		if (companyWide || (ownedByGroup && !uniquePerLayout)) {
+			portletId = PortletIdCodec.decodePortletName(portletId);
+		}
+
+		long ownerId = PortletKeys.PREFS_OWNER_ID_DEFAULT;
+		int ownerType = 0;
+
+		Group group = GroupLocalServiceUtil.fetchGroup(siteGroupId);
+
+		if ((group != null) && group.isLayout()) {
+			plid = group.getClassPK();
+		}
+
+		if (PortletIdCodec.hasUserId(originalPortletId)) {
+			ownerId = PortletIdCodec.decodeUserId(originalPortletId);
+			ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
+		}
+		else if (uniquePerLayout) {
+			ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
+		}
+		else if (ownedByGroup) {
+			plid = PortletKeys.PREFS_PLID_SHARED;
+
+			if (siteGroupId > LayoutConstants.DEFAULT_PLID) {
+				ownerId = siteGroupId;
+			}
+			else {
+				ownerId = layoutGroupId;
+			}
+
+			ownerType = PortletKeys.PREFS_OWNER_TYPE_GROUP;
+		}
+		else if (companyWide) {
+			plid = PortletKeys.PREFS_PLID_SHARED;
+
+			ownerId = companyId;
+			ownerType = PortletKeys.PREFS_OWNER_TYPE_COMPANY;
+		}
+
+		if ((ownerType == 0) || ((ownerId == 0) && (plid == 0))) {
+			throw new IllegalArgumentException();
+		}
+
+		return new PortletPreferencesIds(
+			companyId, ownerId, ownerType, plid, portletId);
+	}
+
+	@Override
+	public PortletPreferencesIds getPortletPreferencesIds(
 		long companyId, long siteGroupId, long plid, String portletId,
 		String settingsScope) {
 
@@ -759,65 +821,24 @@ public class PortletPreferencesFactoryImpl
 		long companyId, long siteGroupId, long layoutGroupId, long plid,
 		String portletId, String defaultPreferences, boolean strictMode) {
 
-		String originalPortletId = portletId;
-
-		Portlet portlet = PortletLocalServiceUtil.getPortletById(
-			companyId, portletId);
-
-		boolean uniquePerLayout = portlet.isPreferencesUniquePerLayout();
-		boolean ownedByGroup = portlet.isPreferencesOwnedByGroup();
-		boolean companyWide = portlet.isPreferencesCompanyWide();
-
-		if (companyWide || (ownedByGroup && !uniquePerLayout)) {
-			portletId = PortletIdCodec.decodePortletName(portletId);
-		}
-
-		long ownerId = PortletKeys.PREFS_OWNER_ID_DEFAULT;
-		int ownerType = 0;
-
-		Group group = GroupLocalServiceUtil.fetchGroup(siteGroupId);
-
-		if ((group != null) && group.isLayout()) {
-			plid = group.getClassPK();
-		}
-
-		if (PortletIdCodec.hasUserId(originalPortletId)) {
-			ownerId = PortletIdCodec.decodeUserId(originalPortletId);
-			ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
-		}
-		else if (uniquePerLayout) {
-			ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
-		}
-		else if (ownedByGroup) {
-			plid = PortletKeys.PREFS_PLID_SHARED;
-
-			if (siteGroupId > LayoutConstants.DEFAULT_PLID) {
-				ownerId = siteGroupId;
-			}
-			else {
-				ownerId = layoutGroupId;
-			}
-
-			ownerType = PortletKeys.PREFS_OWNER_TYPE_GROUP;
-		}
-		else if (companyWide) {
-			plid = PortletKeys.PREFS_PLID_SHARED;
-
-			ownerId = companyId;
-			ownerType = PortletKeys.PREFS_OWNER_TYPE_COMPANY;
-		}
-
-		if ((ownerType == 0) || ((ownerId == 0) && (plid == 0))) {
-			return null;
-		}
+		PortletPreferencesIds portletPreferencesIds = getPortletPreferencesIds(
+			companyId, siteGroupId, layoutGroupId, plid, portletId);
 
 		if (strictMode) {
 			return PortletPreferencesLocalServiceUtil.getStrictPreferences(
-				companyId, ownerId, ownerType, plid, portletId);
+				portletPreferencesIds.getCompanyId(),
+				portletPreferencesIds.getOwnerId(),
+				portletPreferencesIds.getOwnerType(),
+				portletPreferencesIds.getPlid(),
+				portletPreferencesIds.getPortletId());
 		}
 
 		return PortletPreferencesLocalServiceUtil.getPreferences(
-			companyId, ownerId, ownerType, plid, portletId, defaultPreferences);
+			portletPreferencesIds.getCompanyId(),
+			portletPreferencesIds.getOwnerId(),
+			portletPreferencesIds.getOwnerType(),
+			portletPreferencesIds.getPlid(),
+			portletPreferencesIds.getPortletId(), defaultPreferences);
 	}
 
 	protected Map<String, Preference> toPreferencesMap(String xml) {

--- a/portal-impl/src/com/liferay/portlet/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.4.0

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletPreferencesFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletPreferencesFactory.java
@@ -98,6 +98,11 @@ public interface PortletPreferencesFactory {
 		throws PortalException;
 
 	public PortletPreferencesIds getPortletPreferencesIds(
+			long companyId, long siteGroupId, long layoutGroupId, long plid,
+			String portletId)
+		throws IllegalArgumentException;
+
+	public PortletPreferencesIds getPortletPreferencesIds(
 		long companyId, long siteGroupId, long plid, String portletId,
 		String settingsScope);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 10.1.0
+version 10.2.0


### PR DESCRIPTION
Hi @Preston-Crary ,
Sorry I dont know whom should I send this pull to.

The goal with this pull is to enforce portletPreferences generation, so that no invalid combination of ownerId, ownerType and plid will be generated in portletPreferences.

Previous, portal generates portletPreferences of ownerId = 0, ownerType = 3 and plid = 0, I have resolved the issues in other sibling tickets.  