### PR TITLE
LPS-120503 Fix transaction boundary for lazy creation.

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -1067,7 +1067,7 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 				//String body = subject;
 
-				message = addDiscussionMessage(
+				message = mbMessageLocalService.addDiscussionMessage(
 					userId, null, groupId, className, classPK, 0,
 					MBMessageConstants.DEFAULT_PARENT_MESSAGE_ID, subject,
 					subject, new ServiceContext());


### PR DESCRIPTION
@hhuijser can you create a SF rule for ones like this? For local/remote service impls, if they call a public add* method inside a get* method they should call through their field like this.  Even better is if you can check the annotation on the service interface to see if a `@Transactional(readOnly = true)` method is calling another method that is not read only rather than looking at the method name.

CC @shuyangzhou