### PR TITLE
LPS-123199

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
@@ -822,11 +822,15 @@ public class StagedLayoutSetStagedModelDataHandler
 		for (long plid : updatedPlids) {
 			Layout layout = _layoutLocalService.fetchLayout(plid);
 
-			layout.setPriority(layoutPriorities.get(plid));
+			int layoutPriority = layoutPriorities.get(plid);
 
-			_layoutLocalService.updateLayout(layout);
+			if (layout.getPriority() != layoutPriority) {
+				layout.setPriority(layoutPriority);
 
-			parentLayoutIds.add(layout.getParentLayoutId());
+				_layoutLocalService.updateLayout(layout);
+
+				parentLayoutIds.add(layout.getParentLayoutId());
+			}
 		}
 
 		for (long parentLayoutId : parentLayoutIds) {

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/portlet/action/ApplicationsMenuMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/portlet/action/ApplicationsMenuMVCResourceCommand.java
@@ -266,7 +266,7 @@ public class ApplicationsMenuMVCResourceCommand extends BaseMVCResourceCommand {
 		int max = 8;
 
 		List<Group> recentGroups = _recentGroupManager.getRecentGroups(
-			httpServletRequest);
+			httpServletRequest, max + 1);
 
 		if (ListUtil.isNotEmpty(recentGroups)) {
 			sitesJSONObject.put(

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
@@ -394,14 +394,19 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 
 	public boolean isShowSiteSelector() throws PortalException {
 		List<Group> mySites = getMySites();
+
+		if (!mySites.isEmpty()) {
+			return true;
+		}
+
 		List<Group> recentSites = _recentGroupManager.getRecentGroups(
 			PortalUtil.getHttpServletRequest(_portletRequest), 1);
 
-		if (mySites.isEmpty() && recentSites.isEmpty()) {
-			return false;
+		if (!recentSites.isEmpty()) {
+			return true;
 		}
 
-		return true;
+		return false;
 	}
 
 	public boolean isShowStagingInfo() throws PortalException {

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
@@ -395,7 +395,7 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 	public boolean isShowSiteSelector() throws PortalException {
 		List<Group> mySites = getMySites();
 		List<Group> recentSites = _recentGroupManager.getRecentGroups(
-			PortalUtil.getHttpServletRequest(_portletRequest));
+			PortalUtil.getHttpServletRequest(_portletRequest), 1);
 
 		if (mySites.isEmpty() && recentSites.isEmpty()) {
 			return false;

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/menu/MySitesPersonalMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/menu/MySitesPersonalMenuEntry.java
@@ -117,7 +117,7 @@ public class MySitesPersonalMenuEntry implements PersonalMenuEntry {
 			PropsValues.MY_SITES_MAX_ELEMENTS);
 
 		List<Group> recentGroups = _recentGroupManager.getRecentGroups(
-			_portal.getHttpServletRequest(portletRequest));
+			_portal.getHttpServletRequest(portletRequest), 1);
 
 		if (mySiteGroups.isEmpty() && recentGroups.isEmpty()) {
 			return false;

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/menu/MySitesPersonalMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/menu/MySitesPersonalMenuEntry.java
@@ -116,14 +116,18 @@ public class MySitesPersonalMenuEntry implements PersonalMenuEntry {
 			},
 			PropsValues.MY_SITES_MAX_ELEMENTS);
 
+		if (!mySiteGroups.isEmpty()) {
+			return true;
+		}
+
 		List<Group> recentGroups = _recentGroupManager.getRecentGroups(
 			_portal.getHttpServletRequest(portletRequest), 1);
 
-		if (mySiteGroups.isEmpty() && recentGroups.isEmpty()) {
-			return false;
+		if (!recentGroups.isEmpty()) {
+			return true;
 		}
 
-		return true;
+		return false;
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java
@@ -83,7 +83,18 @@ public class RecentGroupManager {
 		_setRecentGroupsValue(httpServletRequest, StringUtil.merge(groupIds));
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getRecentGroups(HttpServletRequest, int)}
+	 */
+	@Deprecated
 	public List<Group> getRecentGroups(HttpServletRequest httpServletRequest) {
+		return getRecentGroups(httpServletRequest, 0);
+	}
+
+	public List<Group> getRecentGroups(
+		HttpServletRequest httpServletRequest, int end) {
+
 		String value = _getRecentGroupsValue(httpServletRequest);
 
 		try {
@@ -91,7 +102,7 @@ public class RecentGroupManager {
 				(PortletRequest)httpServletRequest.getAttribute(
 					JavaConstants.JAVAX_PORTLET_REQUEST);
 
-			return getRecentGroups(value, portletRequest);
+			return getRecentGroups(value, portletRequest, end);
 		}
 		catch (Exception exception) {
 			_log.error("Unable to get recent groups", exception);
@@ -127,8 +138,20 @@ public class RecentGroupManager {
 		return groups;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getRecentGroups(String, PortletRequest, int)}
+	 */
+	@Deprecated
 	protected List<Group> getRecentGroups(
 			String value, PortletRequest portletRequest)
+		throws Exception {
+
+		return getRecentGroups(value, portletRequest, 0);
+	}
+
+	protected List<Group> getRecentGroups(
+			String value, PortletRequest portletRequest, int end)
 		throws Exception {
 
 		long[] groupIds = StringUtil.split(value, 0L);
@@ -177,6 +200,10 @@ public class RecentGroupManager {
 			}
 
 			groups.add(group);
+
+			if ((end > 0) && (groups.size() >= end)) {
+				break;
+			}
 		}
 
 		return groups;

--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
@@ -1402,6 +1402,9 @@ public class SitesImpl implements Sites {
 			Map<String, String[]> parameterMap =
 				getLayoutSetPrototypesParameters(importData);
 
+			parameterMap.put(
+				"lastMergeTime", new String[] {String.valueOf(lastMergeTime)});
+
 			importLayoutSetPrototype(
 				layoutSetPrototype, layoutSet.getGroupId(),
 				layoutSet.isPrivateLayout(), parameterMap, importData);
@@ -1891,13 +1894,30 @@ public class SitesImpl implements Sites {
 		List<Layout> layoutSetPrototypeLayouts =
 			LayoutLocalServiceUtil.getLayouts(layoutSetPrototypeGroupId, true);
 
-		Map<String, Serializable> exportLayoutSettingsMap =
-			ExportImportConfigurationSettingsMapFactoryUtil.
-				buildExportLayoutSettingsMap(
-					user, layoutSetPrototypeGroupId, true,
-					ExportImportHelperUtil.getLayoutIds(
-						layoutSetPrototypeLayouts),
-					parameterMap);
+		Map<String, Serializable> exportLayoutSettingsMap;
+
+		if (parameterMap.containsKey("lastMergeTime")) {
+			String lastMergeTime = parameterMap.get("lastMergeTime")[0];
+
+			exportLayoutSettingsMap =
+				ExportImportConfigurationSettingsMapFactoryUtil.
+					buildExportLayoutSettingsMap(
+						user, layoutSetPrototypeGroupId, true,
+						ArrayUtil.toArray(
+							_getUpdatedLayoutIds(
+								Long.valueOf(lastMergeTime),
+								layoutSetPrototypeLayouts)),
+						parameterMap);
+		}
+		else {
+			exportLayoutSettingsMap =
+				ExportImportConfigurationSettingsMapFactoryUtil.
+					buildExportLayoutSettingsMap(
+						user, layoutSetPrototypeGroupId, true,
+						ExportImportHelperUtil.getLayoutIds(
+							layoutSetPrototypeLayouts),
+						parameterMap);
+		}
 
 		ExportImportConfiguration exportImportConfiguration = null;
 
@@ -2257,6 +2277,22 @@ public class SitesImpl implements Sites {
 		}
 
 		return owner;
+	}
+
+	private Long[] _getUpdatedLayoutIds(
+		long lastMergeTime, List<Layout> layouts) {
+
+		List<Long> layoutIds = new ArrayList<>();
+
+		for (Layout layout : layouts) {
+			Date layoutModifiedDate = layout.getModifiedDate();
+
+			if (layoutModifiedDate.getTime() >= lastMergeTime) {
+				layoutIds.add(layout.getLayoutId());
+			}
+		}
+
+		return layoutIds.toArray(new Long[0]);
 	}
 
 	private void _releaseLock(String className, long classPK, String owner) {

--- a/source-formatter-api-signature-check-exceptions.txt
+++ b/source-formatter-api-signature-check-exceptions.txt
@@ -413,6 +413,7 @@ com.liferay.site.navigation.type.SiteNavigationMenuItemType#getResetMaxStateURL(
 com.liferay.site.util.RecentGroupManager#addRecentGroup(HttpServletRequest,Group)
 com.liferay.site.util.RecentGroupManager#addRecentGroup(HttpServletRequest,long)
 com.liferay.site.util.RecentGroupManager#getRecentGroups(HttpServletRequest)
+com.liferay.site.util.RecentGroupManager#getRecentGroups(HttpServletRequest,int)
 com.liferay.sites.kernel.util.Sites#addPortletBreadcrumbEntries(Group,HttpServletRequest,PortletURL)
 com.liferay.sites.kernel.util.Sites#addPortletBreadcrumbEntries(Group,HttpServletRequest,RenderResponse)
 com.liferay.sites.kernel.util.Sites#addPortletBreadcrumbEntries(Group,String,PortletURL,HttpServletRequest,RenderResponse)


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-123199

Sending as follow-up to https://github.com/Preston-Crary/liferay-portal/pull/1243

Answering your comments:

- https://github.com/Preston-Crary/liferay-portal/pull/1243#pullrequestreview-526494190 - Done, see https://github.com/Preston-Crary/liferay-portal/commit/895d8687efb9eb5a57351acfb3c70255e3f7b397

- https://github.com/Preston-Crary/liferay-portal/pull/1243#pullrequestreview-526495236 - Done, see https://github.com/Preston-Crary/liferay-portal/commit/895d8687efb9eb5a57351acfb3c70255e3f7b397

- https://github.com/Preston-Crary/liferay-portal/pull/1243#pullrequestreview-526496200 - If we haven't modified a given layout's priority, then we shouldn't need to ensure it's priority meshes with it's siblings, unless they have their priority modified.  If this is the case, then we are still good because we have added it's parent to the list.

- https://github.com/Preston-Crary/liferay-portal/pull/1243#pullrequestreview-526498833 - See https://github.com/Preston-Crary/liferay-portal/commit/d79b1a65378370f7e11d6f3124e71d2c32a3f12a and https://github.com/Preston-Crary/liferay-portal/commit/71508ab0453b831e6ee65636ce93bdf790b362bf.  The solution is to allow for an upper-limit of returned results - or more importantly - fetches.  There is now a limit set everywhere it is safe to do so.  The only call which we no longer set a limit is [RecentSitesItemSelectorViewDisplayContext.getGroupSearch()](https://github.com/liferay/liferay-portal/blob/master/modules/apps/site/site-item-selector-web/src/main/java/com/liferay/site/item/selector/web/internal/display/context/RecentSitesItemSelectorViewDisplayContext.java#L73-L92).  This method should return all results, since the "total" value is used and page pagination can occur.

Please let me know if you have any other questions, thanks!