### PR TITLE
COMMERCE-5145 Check CTAware annotations for resource impls and set CT…

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly group: "org.springframework", name: "spring-tx", version: "5.2.2.RELEASE"
 	compileOnly project(":apps:batch-engine:batch-engine-api")
+	compileOnly project(":apps:change-tracking:change-tracking-api")
 	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:headless:headless-batch-engine:headless-batch-engine-api")
@@ -66,6 +67,7 @@ dependencies {
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-string")
 
 	testCompile group: "org.hamcrest", name: "hamcrest-all", version: "1.3"

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/CTContainerRequestFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/CTContainerRequestFilter.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.container.request.filter;
+
+import com.liferay.change.tracking.constants.CTConstants;
+import com.liferay.petra.lang.SafeClosable;
+import com.liferay.petra.reflect.AnnotationLocator;
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+
+import java.lang.reflect.Method;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.cxf.interceptor.InterceptorChain;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.apache.cxf.phase.PhaseInterceptorChain;
+
+/**
+ * @author Preston Crary
+ */
+@Provider
+public class CTContainerRequestFilter implements ContainerRequestFilter {
+
+	@Override
+	public void filter(ContainerRequestContext containerRequestContext) {
+		Message message = PhaseInterceptorChain.getCurrentMessage();
+
+		InterceptorChain interceptorChain = message.getInterceptorChain();
+
+		interceptorChain.add(_CT_PRE_INVOKE_INTERCEPTOR);
+		interceptorChain.add(_CT_POST_INVOKE_INTERCEPTOR);
+	}
+
+	private static final String _CT_COLLECTION_SAFE_CLOSABLE =
+		CTPreInvokeInterceptor.class.getName() + "#CT_COLLECTION_SAFE_CLOSABLE";
+
+	private static final CTPostInvokeInterceptor _CT_POST_INVOKE_INTERCEPTOR =
+		new CTPostInvokeInterceptor();
+
+	private static final CTPreInvokeInterceptor _CT_PRE_INVOKE_INTERCEPTOR =
+		new CTPreInvokeInterceptor();
+
+	private static class CTPostInvokeInterceptor
+		extends AbstractPhaseInterceptor<Message> {
+
+		@Override
+		public void handleMessage(Message message) {
+			SafeClosable safeClosable = (SafeClosable)message.get(
+				_CT_COLLECTION_SAFE_CLOSABLE);
+
+			if (safeClosable != null) {
+				safeClosable.close();
+			}
+		}
+
+		private CTPostInvokeInterceptor() {
+			super(Phase.POST_INVOKE);
+		}
+
+	}
+
+	private static class CTPreInvokeInterceptor
+		extends AbstractPhaseInterceptor<Message> {
+
+		@Override
+		public void handleMessage(Message message) {
+			Method method = (Method)message.get(
+				"org.apache.cxf.resource.method");
+
+			if ((method != null) &&
+				!CTCollectionThreadLocal.isProductionMode()) {
+
+				CTAware ctAware = AnnotationLocator.locate(
+					method, method.getDeclaringClass(), CTAware.class);
+
+				if ((ctAware == null) || ctAware.onProduction()) {
+					message.put(
+						_CT_COLLECTION_SAFE_CLOSABLE,
+						CTCollectionThreadLocal.setCTCollectionId(
+							CTConstants.CT_COLLECTION_ID_PRODUCTION));
+				}
+			}
+		}
+
+		private CTPreInvokeInterceptor() {
+			super(Phase.PRE_INVOKE);
+		}
+
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
@@ -31,6 +31,7 @@ import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.internal.configuration.util.ConfigurationUtil;
+import com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.CTContainerRequestFilter;
 import com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.ContextContainerRequestFilter;
 import com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.LogContainerRequestFilter;
 import com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.NestedFieldsContainerRequestFilter;
@@ -106,6 +107,7 @@ public class VulcanFeature implements Feature {
 		featureContext.register(BeanValidationInterceptor.class);
 		featureContext.register(EntityExtensionWriterInterceptor.class);
 		featureContext.register(ExceptionMapper.class);
+		featureContext.register(CTContainerRequestFilter.class);
 		featureContext.register(DateParamConverterProvider.class);
 		featureContext.register(FieldsQueryParamContextProvider.class);
 		featureContext.register(JacksonJsonProvider.class);


### PR DESCRIPTION
…CollectionThreadLocal accordingly. We have to do this because TransactionContainerRequestFilter sets up a high level transaction boundary.