### PR TITLE
[TS] LPS-123005 Same model children are not optional

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/reference/TableReferenceDefinitionManager.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/reference/TableReferenceDefinitionManager.java
@@ -96,6 +96,10 @@ public class TableReferenceDefinitionManager {
 	public boolean isChildModelOptional(
 		long childModelClassNameId, long parentModelClassNameId) {
 
+		if (childModelClassNameId == parentModelClassNameId) {
+			return false;
+		}
+
 		Map<Long, TableReferenceInfo<?>> combinedTableReferenceInfos =
 			getCombinedTableReferenceInfos();
 


### PR DESCRIPTION
Hi @Preston-Crary

Content page Layouts have a "strong reference" to a draft Layout. Discarding changes on the live Layout will have the Publication's own live Layout discarded, which needs to discard the draft Layout as well.

If I understand this correctly, `childTableJoinHoldersMap.get(childTableReferenceDefinition.getTable())` will always return null as a self reference is not created.

Can you please review?
https://issues.liferay.com/browse/LPS-123005

Thanks,
Balázs