### PR TITLE
LPS-134946 Duplicate user group

### DIFF
--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/SearchCTTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/SearchCTTest.java
@@ -122,10 +122,13 @@ public class SearchCTTest {
 				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 					_ctCollection1.getCtCollectionId())) {
 
-			_productionUserGroup.setName("P1 UserGroup");
+			UserGroup productionUserGroup = _userGroupLocalService.getUserGroup(
+				_productionUserGroup.getUserGroupId());
+
+			productionUserGroup.setName("P1 UserGroup");
 
 			modifiedUserGroup1 = _userGroupLocalService.updateUserGroup(
-				_productionUserGroup);
+				productionUserGroup);
 		}
 
 		_ctCollection2 = _ctCollectionLocalService.addCTCollection(
@@ -139,10 +142,13 @@ public class SearchCTTest {
 				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 					_ctCollection2.getCtCollectionId())) {
 
-			_productionUserGroup.setName("P2 UserGroup");
+			UserGroup productionUserGroup = _userGroupLocalService.getUserGroup(
+				_productionUserGroup.getUserGroupId());
+
+			productionUserGroup.setName("P2 UserGroup");
 
 			modifiedUserGroup2 = _userGroupLocalService.updateUserGroup(
-				_productionUserGroup);
+				productionUserGroup);
 		}
 
 		assertProductionHits(_USER_GROUP_CLASS, _productionUserGroup);

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/SearchCTTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/search/test/SearchCTTest.java
@@ -211,7 +211,7 @@ public class SearchCTTest {
 		assertCollectionHits(
 			_ctCollection1.getCtCollectionId(), _JOURNAL_ARTICLE_CLASS,
 			new JournalArticle[] {addedJournalArticle, modifiedJournalArticle2},
-			new JournalArticle[0]);
+			new JournalArticle[] {modifiedJournalArticle1});
 
 		assertProductionHits(_LAYOUT_CLASS, deletedLayout, modifiedLayout);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-134946

I'm not 100% sure what the intended behavior is for the testCollectionVersusProduction case here: https://github.com/Preston-Crary/liferay-portal/commit/97cd9d0b1aa39fc4e2b3e4420a54c2711949e0b7. The change I made reverts a change I made in the past when creating `JournalArticleCTSearchEventListener` to fix a related bug. 

The original unmodified article from production is still present since it doesn't get added to the excluded PK list in `CTModelPreFilterContributor` due to Journal Article modifications technically being considered as CT additions because a new version is created. It doesn't appear twice in the font end, but it does appear twice  (original from production + version modified in publication) in the search results for this test case. Wanted to make sure this is the correct assertion for the test case even though the front end works as expected.